### PR TITLE
Correct the return type of APIClient.get_historical_data

### DIFF
--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -156,7 +156,7 @@ class APIClient:
         range_start: str = "",
         range_end: str = "",
         results = 300
-    ) -> dict:
+    ) -> pd.DataFrame:
         """Initiates a REST API call"""
 
         # validate symbol


### PR DESCRIPTION
The return type was typed to be dict, however it's actually a pandas DataFrame