### PR TITLE
Handle non-json http error responses and use requests.exceptions.JSONDecodeError instead of json.JSONDecodeError

### DIFF
--- a/eodhd/APIs/BaseAPI.py
+++ b/eodhd/APIs/BaseAPI.py
@@ -1,9 +1,8 @@
-from json.decoder import JSONDecodeError
 import sys
 from requests import get as requests_get
 from requests import ConnectionError as requests_ConnectionError
 from requests import Timeout as requests_Timeout
-from requests.exceptions import HTTPError as requests_HTTPError
+from requests.exceptions import HTTPError as requests_HTTPError, JSONDecodeError as requests_JSONDecodeError
 from rich.console import Console
 
 class BaseAPI:
@@ -35,7 +34,7 @@ class BaseAPI:
                     message = f"({resp.status_code}) {self._api_url} - {resp_message}"
                     self.console.log(message)
 
-                except JSONDecodeError as err:
+                except requests_JSONDecodeError as err:
                     self.console.log(err)
 
             try:

--- a/eodhd/APIs/BaseAPI.py
+++ b/eodhd/APIs/BaseAPI.py
@@ -23,7 +23,9 @@ class BaseAPI:
 
             if resp.status_code != 200:
                 try:
-                    if "message" in resp.json():
+                    if resp.headers.get("Content-Type") != 'application/json':
+                        resp_message = resp.text
+                    elif "message" in resp.json():
                         resp_message = resp.json()["message"]
                     elif "errors" in resp.json():
                         self.console.log(resp.json())

--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -118,7 +118,9 @@ class APIClient:
 
             if resp.status_code != 200:
                 try:
-                    if "message" in resp.json():
+                    if resp.headers.get("Content-Type") != 'application/json':
+                        resp_message = resp.text
+                    elif "message" in resp.json():
                         resp_message = resp.json()["message"]
                     elif "errors" in resp.json():
                         self.console.log(resp.json())

--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -1,6 +1,5 @@
 """apiclient.py"""
 
-from json.decoder import JSONDecodeError
 import sys
 from enum import Enum
 from datetime import datetime
@@ -11,7 +10,7 @@ import numpy as np
 from requests import get as requests_get
 from requests import ConnectionError as requests_ConnectionError
 from requests import Timeout as requests_Timeout
-from requests.exceptions import HTTPError as requests_HTTPError
+from requests.exceptions import HTTPError as requests_HTTPError, JSONDecodeError as requests_JSONDecodeError
 from rich.console import Console
 from rich.progress import track
 
@@ -130,7 +129,7 @@ class APIClient:
                     message = f"({resp.status_code}) {self._api_url} - {resp_message}"
                     self.console.log(message)
 
-                except JSONDecodeError as err:
+                except requests_JSONDecodeError as err:
                     self.console.log(err)
 
             try:


### PR DESCRIPTION
Requests has attempted to consolidate json decoding errors in https://github.com/psf/requests/pull/5856 which was released in requests==2.27.0. Since this project is requests>=2.31.0 we are safe to incorporate the change.

eodhd.com returns a text/html response for `api.get_bonds_fundamentals_data` if you are using a non-fundamentals api key.