### PR TITLE
fix: add error hierarchy, session pooling, timeouts, WS reconnect

### DIFF
--- a/eodhd/APIs/BaseAPI.py
+++ b/eodhd/APIs/BaseAPI.py
@@ -1,57 +1,66 @@
 # APIs/BaseAPI.py
 
 from json.decoder import JSONDecodeError
-from requests import get as requests_get
+import requests
 from requests import ConnectionError as requests_ConnectionError
 from requests import Timeout as requests_Timeout
-from requests.exceptions import HTTPError as requests_HTTPError
 from rich.console import Console
+
+from eodhd.errors import EODHDHTTPError, EODHDConnectionError, EODHDTimeoutError
 
 
 class BaseAPI:
 
-    def __init__(self) -> None:
+    def __init__(self, session: requests.Session = None, timeout: tuple = (5.0, 30.0)) -> None:
         self._api_url = "https://eodhd.com/api"
+        self._session = session
+        self._timeout = timeout
         self.console = Console()
 
+    def _do_get(self, url: str):
+        """Execute GET using session if available, else bare requests.get."""
+        if self._session is not None:
+            return self._session.get(url, timeout=self._timeout)
+        return requests.get(url, timeout=self._timeout)
+
     def _rest_get_method(self, api_key: str, endpoint: str = "", uri: str = "", querystring: str = ""):
-        """Generic REST GET"""
+        """Generic REST GET — raises EODHDHTTPError/EODHDConnectionError/EODHDTimeoutError on failure."""
 
         if endpoint.strip() == "":
             raise ValueError("endpoint is empty!")
 
+        url = f"{self._api_url}/{endpoint}/{uri}?api_token={api_key}&fmt=json{querystring}"
+
         try:
-            resp = requests_get(f"{self._api_url}/{endpoint}/{uri}?api_token={api_key}&fmt=json{querystring}")
+            resp = self._do_get(url)
+        except requests_ConnectionError as err:
+            raise EODHDConnectionError(str(err)) from err
+        except requests_Timeout as err:
+            raise EODHDTimeoutError(str(err)) from err
 
-            if resp.status_code != 200:
-                try:
-                    if "message" in resp.json():
-                        resp_message = resp.json()["message"]
-                    elif "errors" in resp.json():
-                        errors = resp.json()
-                        self.console.log(errors)
-                        raise RuntimeError(f"EODHD API returned errors (HTTP {resp.status_code}): {errors}")
-                    else:
-                        resp_message = ""
-
-                    message = f"({resp.status_code}) {self._api_url} - {resp_message}"
-                    self.console.log(message)
-
-                except JSONDecodeError as err:
-                    self.console.log(err)
+        if resp.status_code != 200:
+            try:
+                body = resp.text
+            except Exception:
+                body = ""
 
             try:
-                resp.raise_for_status()
+                data = resp.json()
+                message = data.get("message", "") or str(data.get("errors", ""))
+            except (JSONDecodeError, ValueError):
+                message = ""
 
-                return resp.json()
+            raise EODHDHTTPError(
+                status_code=resp.status_code,
+                response_body=body,
+                message=f"({resp.status_code}) {self._api_url} - {message}" if message else f"HTTP {resp.status_code}",
+            )
 
-            except ValueError as err:
-                self.console.log(err)
-
-        except requests_ConnectionError as err:
-            self.console.log(err)
-        except requests_HTTPError as err:
-            self.console.log(err)
-        except requests_Timeout as err:
-            self.console.log(err)
-        return {}
+        try:
+            return resp.json()
+        except (JSONDecodeError, ValueError) as err:
+            raise EODHDHTTPError(
+                status_code=resp.status_code,
+                response_body=resp.text,
+                message=f"Invalid JSON response: {err}",
+            ) from err

--- a/eodhd/__init__.py
+++ b/eodhd/__init__.py
@@ -4,6 +4,7 @@ from eodhd.apiclient import APIClient
 from eodhd.apiclient import ScannerClient
 from eodhd.eodhdgraphs import EODHDGraphs
 from eodhd.websocketclient import WebSocketClient
+from eodhd.errors import EODHDError, EODHDHTTPError, EODHDConnectionError, EODHDTimeoutError
 from eodhd import APIs
 
 

--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -8,12 +8,13 @@ from datetime import timedelta
 from re import compile as re_compile
 import pandas as pd
 import numpy as np
-from requests import get as requests_get
+import requests
 from requests import ConnectionError as requests_ConnectionError
 from requests import Timeout as requests_Timeout
-from requests.exceptions import HTTPError as requests_HTTPError
 from rich.console import Console
 from rich.progress import track
+
+from eodhd.errors import EODHDHTTPError, EODHDConnectionError, EODHDTimeoutError
 
 from eodhd.APIs import HistoricalDividendsAPI, UpcomingDividendsAPI
 from eodhd.APIs import HistoricalSplitsAPI
@@ -107,7 +108,7 @@ class DateUtils:
 class APIClient:
     """API class"""
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, timeout: tuple = (5.0, 30.0)) -> None:
         # Validate API key
         prog = re_compile(r"^[A-z0-9.]{16,32}$")
         if api_key != "demo" and not prog.match(api_key):
@@ -115,53 +116,65 @@ class APIClient:
 
         self._api_key = api_key
         self._api_url = "https://eodhd.com/api"
+        self._timeout = timeout
+        self._session = requests.Session()
 
         self.console = Console()
 
+    def close(self):
+        """Close the underlying HTTP session."""
+        self._session.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     def _rest_get(self, endpoint: str = "", uri: str = "", querystring: str = "") -> pd.DataFrame():
-        """Generic REST GET"""
+        """Generic REST GET — raises EODHDHTTPError/EODHDConnectionError/EODHDTimeoutError on failure."""
 
         if endpoint.strip() == "":
             raise ValueError("endpoint is empty!")
 
+        url = f"{self._api_url}/{endpoint}/{uri}?api_token={self._api_key}&fmt=json{querystring}"
+
         try:
-            resp = requests_get(f"{self._api_url}/{endpoint}/{uri}?api_token={self._api_key}&fmt=json{querystring}")
-
-            if resp.status_code != 200:
-                try:
-                    if "message" in resp.json():
-                        resp_message = resp.json()["message"]
-                    elif "errors" in resp.json():
-                        errors = resp.json()
-                        self.console.log(errors)
-                        raise RuntimeError(f"EODHD API returned errors (HTTP {resp.status_code}): {errors}")
-                    else:
-                        resp_message = ""
-
-                    message = f"({resp.status_code}) {self._api_url} - {resp_message}"
-                    self.console.log(message)
-
-                except JSONDecodeError as err:
-                    self.console.log(err)
-
-            try:
-                resp.raise_for_status()
-
-                if isinstance(resp.json(), list):
-                    return pd.DataFrame.from_dict(resp.json())
-                else:
-                    return pd.DataFrame(resp.json(), index=[0])
-
-            except ValueError as err:
-                self.console.log(err)
-
+            resp = self._session.get(url, timeout=self._timeout)
         except requests_ConnectionError as err:
-            self.console.log(err)
-        except requests_HTTPError as err:
-            self.console.log(err)
+            raise EODHDConnectionError(str(err)) from err
         except requests_Timeout as err:
-            self.console.log(err)
-        return pd.DataFrame()
+            raise EODHDTimeoutError(str(err)) from err
+
+        if resp.status_code != 200:
+            try:
+                body = resp.text
+            except Exception:
+                body = ""
+            try:
+                data = resp.json()
+                message = data.get("message", "") or str(data.get("errors", ""))
+            except (JSONDecodeError, ValueError):
+                message = ""
+            raise EODHDHTTPError(
+                status_code=resp.status_code,
+                response_body=body,
+                message=f"({resp.status_code}) {self._api_url} - {message}" if message else f"HTTP {resp.status_code}",
+            )
+
+        try:
+            json_data = resp.json()
+        except (JSONDecodeError, ValueError) as err:
+            raise EODHDHTTPError(
+                status_code=resp.status_code,
+                response_body=resp.text,
+                message=f"Invalid JSON response: {err}",
+            ) from err
+
+        if isinstance(json_data, list):
+            return pd.DataFrame.from_dict(json_data)
+        else:
+            return pd.DataFrame(json_data, index=[0])
 
     def get_exchanges(self) -> pd.DataFrame:
         """Get supported exchanges"""
@@ -482,7 +495,7 @@ class APIClient:
         For more information visit: https://eodhistoricaldata.com/financial-apis/api-splits-dividends/
         """
 
-        api_call = HistoricalDividendsAPI()
+        api_call = HistoricalDividendsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_historical_dividends_data(api_token=self._api_key, ticker=ticker, date_from=date_from, date_to=date_to)
 
     def get_historical_splits_data(self, ticker, date_to=None, date_from=None) -> list:
@@ -494,7 +507,7 @@ class APIClient:
         For more information visit: https://eodhistoricaldata.com/financial-apis/api-splits-dividends/
         """
 
-        api_call = HistoricalSplitsAPI()
+        api_call = HistoricalSplitsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_historical_splits_data(api_token=self._api_key, ticker=ticker, date_from=date_from, date_to=date_to)
 
     def get_technical_indicator_data(
@@ -557,7 +570,7 @@ class APIClient:
         For those functions use this parameters to set periods.
         """
 
-        api_call = TechnicalIndicatorAPI()
+        api_call = TechnicalIndicatorAPI(session=self._session, timeout=self._timeout)
         return api_call.get_technical_indicator_data(
             api_token=self._api_key,
             ticker=ticker,
@@ -588,7 +601,7 @@ class APIClient:
         For more information visit: https://eodhistoricaldata.com/financial-apis/live-realtime-stocks-api/
         """
 
-        api_call = LiveStockPricesAPI()
+        api_call = LiveStockPricesAPI(session=self._session, timeout=self._timeout)
         return api_call.get_live_stock_prices(api_token=self._api_key, ticker=ticker, s=s)
 
     def get_us_extended_quotes(self, s, page_limit=None, page_offset=None, fmt=None) -> list:
@@ -618,7 +631,7 @@ class APIClient:
         For more information visit:
           https://eodhd.com/financial-apis/live-v2-for-us-stocks-extended-quotes-2025
         """
-        api_call = LiveExtendedQuotesAPI()
+        api_call = LiveExtendedQuotesAPI(session=self._session, timeout=self._timeout)
         return api_call.get_us_extended_quotes(
             api_token=self._api_key,
             symbols=s,
@@ -645,7 +658,7 @@ class APIClient:
         For more information visit: https://eodhistoricaldata.com/financial-apis/economic-events-data-api/
         """
 
-        api_call = EconomicEventsDataAPI()
+        api_call = EconomicEventsDataAPI(session=self._session, timeout=self._timeout)
         return api_call.get_economic_events_data(
             api_token=self._api_key,
             date_from=date_from,
@@ -672,7 +685,7 @@ class APIClient:
         For more information visit: https://eodhistoricaldata.com/financial-apis/insider-transactions-api/
         """
 
-        api_call = InsiderTransactionsAPI()
+        api_call = InsiderTransactionsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_insider_transactions_data(
             api_token=self._api_key,
             date_from=date_from,
@@ -687,7 +700,7 @@ class APIClient:
         For more information visit: https://eodhistoricaldata.com/financial-apis/stock-etfs-fundamental-data-feeds/
         """
 
-        api_call = FundamentalDataAPI()
+        api_call = FundamentalDataAPI(session=self._session, timeout=self._timeout)
         return api_call.get_fundamentals_data(api_token=self._api_key, ticker=ticker)
 
     def get_eod_splits_dividends_data(self, country="US", type=None, date=None, symbols=None, filter=None) -> list:
@@ -705,7 +718,7 @@ class APIClient:
         For more information visit: https://eodhistoricaldata.com/financial-apis/bulk-api-eod-splits-dividends/
         """
 
-        api_call = BulkEodSplitsDividendsDataAPI()
+        api_call = BulkEodSplitsDividendsDataAPI(session=self._session, timeout=self._timeout)
         return api_call.get_eod_splits_dividends_data(
             api_token=self._api_key,
             country=country,
@@ -725,7 +738,7 @@ class APIClient:
         For more information visit: https://eodhistoricaldata.com/financial-apis/calendar-upcoming-earnings-ipos-and-splits/#Upcoming_Earnings_API
         """
 
-        api_call = UpcomgingEarningsAPI()
+        api_call = UpcomgingEarningsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_upcoming_earnings_data(
             api_token=self._api_key,
             from_date=from_date,
@@ -740,7 +753,7 @@ class APIClient:
             ou can use one symbol: ‘AAPL.US’ or several symbols separated by a comma: ‘AAPL.US, MS’
         For more information visit: https://eodhistoricaldata.com/financial-apis/calendar-upcoming-earnings-ipos-and-splits/#Earnings_Trends_API
         """
-        api_call = EarningTrendsAPI()
+        api_call = EarningTrendsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_earning_trends_data(api_token=self._api_key, symbols=symbols)
 
     def get_upcoming_IPOs_data(self, from_date=None, to_date=None) -> list:
@@ -750,7 +763,7 @@ class APIClient:
         For more information visit: https://eodhistoricaldata.com/financial-apis/calendar-upcoming-earnings-ipos-and-splits/#Upcoming_Earnings_API
         """
 
-        api_call = UpcomingIPOsAPI()
+        api_call = UpcomingIPOsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_upcoming_IPOs_data(api_token=self._api_key, from_date=from_date, to_date=to_date)
 
     def get_upcoming_splits_data(self, from_date=None, to_date=None) -> list:
@@ -760,7 +773,7 @@ class APIClient:
         For more information visit: https://eodhistoricaldata.com/financial-apis/calendar-upcoming-earnings-ipos-and-splits/#Upcoming_Earnings_API
         """
 
-        api_call = UpcomingSplitsAPI()
+        api_call = UpcomingSplitsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_upcoming_splits_data(api_token=self._api_key, from_date=from_date, to_date=to_date)
 
     def get_upcoming_dividends_data(
@@ -786,7 +799,7 @@ class APIClient:
         Note:
             API requires at least one of `symbol` or `date_eq`.
         """
-        api_call = UpcomingDividendsAPI()
+        api_call = UpcomingDividendsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_upcoming_dividends_data(
             api_token=self._api_key,
             symbol=symbol,
@@ -806,7 +819,7 @@ class APIClient:
         All possible indicators will be avaliable on: https://eodhistoricaldata.com/financial-apis/macroeconomics-data-and-macro-indicators-api/
         """
 
-        api_call = MacroIndicatorsAPI()
+        api_call = MacroIndicatorsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_macro_indicators_data(api_token=self._api_key, country=country, indicator=indicator)
 
 
@@ -815,7 +828,7 @@ class APIClient:
         Function returns list of avaliable exchanges
         """
 
-        api_call = ListOfExchangesAPI()
+        api_call = ListOfExchangesAPI(session=self._session, timeout=self._timeout)
         return api_call.get_list_of_exchanges(api_token=self._api_key)
 
     def get_list_of_tickers(self, code: str, delisted: int = 0, include_delisted: bool = False):
@@ -845,7 +858,7 @@ class APIClient:
         if delisted not in (0, 1):
             raise ValueError("Parameter 'delisted' must be 0 or 1.")
 
-        api_call = ListOfExchangesAPI()
+        api_call = ListOfExchangesAPI(session=self._session, timeout=self._timeout)
 
         if not include_delisted:
             return api_call.get_list_of_tickers(api_token=self._api_key, delisted=delisted, code=code)
@@ -883,7 +896,7 @@ class APIClient:
         For more information visit: https://eodhistoricaldata.com/financial-apis/exchanges-api-trading-hours-and-stock-market-holidays/
         """
 
-        api_call = TradingHours_StockMarketHolidays_SymbolsChangeHistoryAPI()
+        api_call = TradingHours_StockMarketHolidays_SymbolsChangeHistoryAPI(session=self._session, timeout=self._timeout)
         return api_call.get_details_trading_hours_stock_market_holidays(api_token=self._api_key, code=code, from_date=from_date, to_date=to_date)
 
     def symbol_change_history(self, from_date=None, to_date=None):
@@ -892,7 +905,7 @@ class APIClient:
             If you need data from Jul 22, 2022, to Aug 10, 2022, you should use from=2022-07-22 and to=2022-08-10.
         For more information visit: https://eodhistoricaldata.com/financial-apis/exchanges-api-trading-hours-and-stock-market-holidays/
         """
-        api_call = TradingHours_StockMarketHolidays_SymbolsChangeHistoryAPI()
+        api_call = TradingHours_StockMarketHolidays_SymbolsChangeHistoryAPI(session=self._session, timeout=self._timeout)
         return api_call.symbol_change_history(api_token=self._api_key, from_date=from_date, to_date=to_date)
 
     def stock_market_screener(self, sort=None, filters=None, limit=None, signals=None, offset=None):
@@ -907,7 +920,7 @@ class APIClient:
             For example, to get 100 symbols starting from 200 you should use limit=100 and offset=200.
         """
 
-        api_call = StockMarketScreenerAPI()
+        api_call = StockMarketScreenerAPI(session=self._session, timeout=self._timeout)
         return api_call.stock_market_screener(
             api_token=self._api_key,
             filters=filters,
@@ -946,7 +959,7 @@ class APIClient:
         List of supported exchanges: https://eodhd.com/financial-apis/exchanges-api-list-of-tickers-and-trading-hours/
         For more information visit: https://eodhd.com/financial-apis/intraday-historical-data-api/
         """
-        api_call = IntradayDataAPI()
+        api_call = IntradayDataAPI(session=self._session, timeout=self._timeout)
         return api_call.get_intraday_historical_data(
             api_token=self._api_key,
             symbol=symbol,
@@ -976,7 +989,7 @@ class APIClient:
         List of supported exchanges: https://eodhd.com/financial-apis/exchanges-api-list-of-tickers-and-trading-hours/
         For more information visit: https://eodhd.com/financial-apis/api-for-historical-data-and-volumes/
         """
-        api_call = EodHistoricalStockMarketDataAPI()
+        api_call = EodHistoricalStockMarketDataAPI(session=self._session, timeout=self._timeout)
         return api_call.get_eod_historical_stock_market_data(
             api_token=self._api_key,
             symbol=symbol,
@@ -1005,7 +1018,7 @@ class APIClient:
                 correspond to ' 2021-08-02 09:35:00 ' and ' 2021-09-02 09:35:00 '.
             limit - the maximum number of ticks will be provided.
         """
-        api_call = StockMarketTickDataAPI()
+        api_call = StockMarketTickDataAPI(session=self._session, timeout=self._timeout)
         return api_call.get_stock_market_tick_data(
             api_token=self._api_key,
             symbol=symbol,
@@ -1024,7 +1037,7 @@ class APIClient:
             limit (not required) - Number of results (default: 50, min: 1, max: 1000)
             offset (not required) - Offset for pagination (default: 0)
         """
-        api_call = FinancialNewsAPI()
+        api_call = FinancialNewsAPI(session=self._session, timeout=self._timeout)
         return api_call.financial_news(
             api_token=self._api_key,
             s=s,
@@ -1041,7 +1054,7 @@ class APIClient:
             s [REQUIRED] - One or more comma-separated tickers (e.g. "BTC-USD.CC,AAPL.US")
             from_date, to_date [NOT REQUIRED] - YYYY-MM-DD
         """
-        api_call = FinancialNewsAPI()
+        api_call = FinancialNewsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_sentiment(
             api_token=self._api_key,
             s=s,
@@ -1059,7 +1072,7 @@ class APIClient:
             date_to   [NOT REQUIRED] - YYYY-MM-DD (maps to filter[date_to])
             limit     [NOT REQUIRED] - Number of top words to return (maps to page[limit])
         """
-        api_call = FinancialNewsAPI()
+        api_call = FinancialNewsAPI(session=self._session, timeout=self._timeout)
         return api_call.news_word_weights(
             api_token=self._api_key,
             s=s,
@@ -1083,7 +1096,7 @@ class APIClient:
             For more information visit: https://eodhd.com/financial-apis/historical-market-capitalization-api/
         """
 
-        api_call = HistoricalMarketCapitalizationAPI()
+        api_call = HistoricalMarketCapitalizationAPI(session=self._session, timeout=self._timeout)
         return api_call.get_historical_market_capitalization_data(
             api_token=self._api_key,
             ticker=ticker,
@@ -1113,7 +1126,7 @@ class APIClient:
                 date="2017-02-01"
             )
         """
-        api_call = CBOEIndexFeedAPI()
+        api_call = CBOEIndexFeedAPI(session=self._session, timeout=self._timeout)
         return api_call.get_cboe_index_data(
             api_token=self._api_key,
             index_code=index_code,
@@ -1134,7 +1147,7 @@ class APIClient:
         Returns:
             dict with keys: meta, data, links (links.next for pagination)
         """
-        api_call = CBOEIndexFeedAPI()
+        api_call = CBOEIndexFeedAPI(session=self._session, timeout=self._timeout)
         return api_call.get_cboe_indices_list(
             api_token=self._api_key,
             fmt=fmt,
@@ -1167,7 +1180,7 @@ class APIClient:
         Returns:
             dict with meta/data/links (links.next for pagination)
         """
-        api_call = IDMappingAPI()
+        api_call = IDMappingAPI(session=self._session, timeout=self._timeout)
         return api_call.get_id_mapping(
             api_token=self._api_key,
             symbol=symbol,
@@ -1193,7 +1206,7 @@ class APIClient:
         Returns:
             list[dict] - list of indices with fields like Code, Name, Constituents, etc.
         """
-        api_call = MPIndicesListAPI()
+        api_call = MPIndicesListAPI(session=self._session, timeout=self._timeout)
         return api_call.get_indices_list(api_token=self._api_key)
 
     def mp_index_components(self, symbol, historical=None, from_date=None, to_date=None):
@@ -1213,7 +1226,7 @@ class APIClient:
             dict - JSON with keys like "General", "Components",
                    and optionally historical keys.
         """
-        api_call = MPIndexComponentsAPI()
+        api_call = MPIndexComponentsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_index_components(
             api_token=self._api_key,
             symbol=symbol,
@@ -1267,7 +1280,7 @@ class APIClient:
         Returns:
             dict with meta, data[], links.next (pagination)
         """
-        api_call = MPUSOptionsContractsAPI()
+        api_call = MPUSOptionsContractsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_us_options_contracts(
             api_token=self._api_key,
             underlying_symbol=underlying_symbol,
@@ -1338,7 +1351,7 @@ class APIClient:
         Returns:
             dict with meta, data[], links.next (pagination)
         """
-        api_call = MPUSOptionsEODAPI()
+        api_call = MPUSOptionsEODAPI(session=self._session, timeout=self._timeout)
         return api_call.get_us_options_eod(
             api_token=self._api_key,
             underlying_symbol=underlying_symbol,
@@ -1375,7 +1388,7 @@ class APIClient:
         Returns:
             dict with meta, data (list of symbols), links.next
         """
-        api_call = MPUSOptionsUnderlyingSymbolsAPI()
+        api_call = MPUSOptionsUnderlyingSymbolsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_us_options_underlyings(
             api_token=self._api_key,
             page_offset=page_offset,
@@ -1387,13 +1400,13 @@ class APIClient:
 class ScannerClient:
     """Scanner class"""
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, timeout: tuple = (5.0, 30.0)) -> None:
         # Validate API key
         prog = re_compile(r"^[A-z0-9.]{16,32}$")
         if api_key != "demo" and not prog.match(api_key):
             raise ValueError("API key is invalid")
 
-        self.api = APIClient(api_key)
+        self.api = APIClient(api_key, timeout=timeout)
 
     def scan_markets(
         self,

--- a/eodhd/errors.py
+++ b/eodhd/errors.py
@@ -1,0 +1,23 @@
+"""Custom exception hierarchy for the EODHD Python SDK."""
+
+
+class EODHDError(Exception):
+    """Base exception for all EODHD SDK errors."""
+
+
+class EODHDHTTPError(EODHDError):
+    """Raised when the API returns a non-2xx HTTP status."""
+
+    def __init__(self, status_code: int, response_body: str, message: str = ""):
+        self.status_code = status_code
+        self.response_body = response_body
+        self.message = message or f"HTTP {status_code}"
+        super().__init__(self.message)
+
+
+class EODHDConnectionError(EODHDError):
+    """Raised when the API is unreachable."""
+
+
+class EODHDTimeoutError(EODHDError):
+    """Raised when an API request times out."""

--- a/eodhd/websocketclient.py
+++ b/eodhd/websocketclient.py
@@ -20,6 +20,8 @@ class WebSocketClient:
         display_candle_1m: bool = False,
         display_candle_5m: bool = False,
         display_candle_1h: bool = False,
+        max_reconnect_attempts: int = 5,
+        reconnect_base_delay: float = 1.0,
     ) -> None:
         # Validate API key
         prog = re.compile(r"^[A-z0-9.]{16,32}$")
@@ -53,6 +55,8 @@ class WebSocketClient:
         self._display_candle_1m = display_candle_1m
         self._display_candle_5m = display_candle_5m
         self._display_candle_1h = display_candle_1h
+        self._max_reconnect_attempts = max_reconnect_attempts
+        self._reconnect_base_delay = reconnect_base_delay
 
         self.running = True
         self.message = None
@@ -68,7 +72,11 @@ class WebSocketClient:
         print("Stopping websocket...")
         self.running = False
         self.stop_event.set()
-        self.thread.join()
+        if self.ws is not None:
+            try:
+                self.ws.close()
+            except Exception:
+                pass
         print("Websocket stopped.")
 
     def _floor_to_nearest_interval(self, timestamp_ms, interval):
@@ -98,158 +106,124 @@ class WebSocketClient:
         return floored_ms
 
     def _collect_data(self):
-        self.ws = websocket.create_connection(f"wss://ws.eodhistoricaldata.com/ws/{self._endpoint}?api_token={self._api_key}")
+        attempt = 0
 
-        # Send the subscription message
-        payload = {
-            "action": "subscribe",
-            "symbols": ",".join(self._symbols),
-        }
-        self.ws.send(json.dumps(payload))
-
-        candle_1m = {}
-        candle_5m = {}
-        candle_1h = {}
-
-        # Collect data until the stop event is set
         while not self.stop_event.is_set():
-            self.message = self.ws.recv()
-            message_json = json.loads(self.message)
+            try:
+                self.ws = websocket.create_connection(
+                    f"wss://ws.eodhistoricaldata.com/ws/{self._endpoint}?api_token={self._api_key}"
+                )
 
-            if self._store_data:
-                self.data_list.append(self.message)
+                # Send the subscription message
+                payload = {
+                    "action": "subscribe",
+                    "symbols": ",".join(self._symbols),
+                }
+                self.ws.send(json.dumps(payload))
 
-            if self._display_stream:
-                print(self.message)
+                # Reset attempt counter on successful connection
+                attempt = 0
 
-            if self._display_candle_1m:
-                if "t" in message_json:
-                    candle_date = self._floor_to_nearest_interval(message_json["t"], "1 minute")
+                # Reset candle state on each (re)connection — partial candles are misleading
+                candle_1m = {}
+                candle_5m = {}
+                candle_1h = {}
 
-                    if "t" in candle_1m and (candle_date != candle_1m["t"]):
-                        print(candle_1m)
+                # Collect data until the stop event is set
+                while not self.stop_event.is_set():
+                    try:
+                        self.message = self.ws.recv()
+                    except (
+                        websocket.WebSocketConnectionClosedException,
+                        websocket.WebSocketException,
+                        ConnectionError,
+                        OSError,
+                    ):
+                        break
 
-                        # New candle
-                        candle_1m = {}
+                    try:
+                        message_json = json.loads(self.message)
+                    except (json.JSONDecodeError, TypeError):
+                        continue
 
-                    candle_1m["t"] = candle_date
+                    if self._store_data:
+                        self.data_list.append(self.message)
 
-                if "s" in message_json:
-                    candle_1m["m"] = message_json["s"]
-                    candle_1m["g"] = 60
+                    if self._display_stream:
+                        print(self.message)
 
-                if "p" in message_json and "o" not in candle_1m:
-                    # Forming candle
-                    candle_1m["o"] = message_json["p"]
-                    candle_1m["h"] = message_json["p"]
-                    candle_1m["l"] = message_json["p"]
-                    candle_1m["c"] = message_json["p"]
-                    if "q" in message_json:
-                        candle_1m["v"] = float(message_json["q"])
-                elif "p" in message_json and "o" in candle_1m:
-                    # Update candle
-                    candle_1m["c"] = message_json["p"]
+                    if self._display_candle_1m:
+                        self._update_candle(candle_1m, message_json, "1 minute", 60)
 
-                    if message_json["p"] > candle_1m["h"]:
-                        candle_1m["h"] = message_json["p"]
+                    if self._display_candle_5m:
+                        self._update_candle(candle_5m, message_json, "5 minutes", 60)
 
-                    if message_json["p"] < candle_1m["l"]:
-                        candle_1m["l"] = message_json["p"]
+                    if self._display_candle_1h:
+                        self._update_candle(candle_1h, message_json, "1 hour", 60)
 
-                    # Sum volume
-                    candle_1m["v"] += float(message_json["q"])
-
-                # Uncomment this to see the candle forming
-                # print(candle_1m)
-
-            if self._display_candle_5m:
-                if "t" in message_json:
-                    candle_date = self._floor_to_nearest_interval(message_json["t"], "5 minutes")
-
-                    if "t" in candle_5m and (candle_date != candle_5m["t"]):
-                        print(candle_5m)
-
-                        # New candle
-                        candle_5m = {}
-
-                    candle_5m["t"] = candle_date
-
-                if "s" in message_json:
-                    candle_5m["m"] = message_json["s"]
-                    candle_5m["g"] = 60
-
-                if "p" in message_json and "o" not in candle_5m:
-                    # Forming candle
-                    candle_5m["o"] = message_json["p"]
-                    candle_5m["h"] = message_json["p"]
-                    candle_5m["l"] = message_json["p"]
-                    candle_5m["c"] = message_json["p"]
-                    if "q" in message_json:
-                        candle_5m["v"] = float(message_json["q"])
-                elif "p" in message_json and "o" in candle_5m:
-                    # Update candle
-                    candle_5m["c"] = message_json["p"]
-
-                    if message_json["p"] > candle_5m["h"]:
-                        candle_5m["h"] = message_json["p"]
-
-                    if message_json["p"] < candle_5m["l"]:
-                        candle_5m["l"] = message_json["p"]
-
-                    # Sum volume
-                    candle_5m["v"] += float(message_json["q"])
-
-                # Uncomment this to see the candle forming
-                # print(candle_5m)
-
-            if self._display_candle_1h:
-                if "t" in message_json:
-                    candle_date = self._floor_to_nearest_interval(message_json["t"], "1 hour")
-
-                    if "t" in candle_1h and (candle_date != candle_1h["t"]):
-                        print(candle_1h)
-
-                        # New candle
-                        candle_1h = {}
-
-                    candle_1h["t"] = candle_date
-
-                if "s" in message_json:
-                    candle_1h["m"] = message_json["s"]
-                    candle_1h["g"] = 60
-
-                if "p" in message_json and "o" not in candle_1h:
-                    # Forming candle
-                    candle_1h["o"] = message_json["p"]
-                    candle_1h["h"] = message_json["p"]
-                    candle_1h["l"] = message_json["p"]
-                    candle_1h["c"] = message_json["p"]
-                    if "q" in message_json:
-                        candle_1h["v"] = float(message_json["q"])
-                elif "p" in message_json and "o" in candle_1h:
-                    # Update candle
-                    candle_1h["c"] = message_json["p"]
-
-                    if message_json["p"] > candle_1h["h"]:
-                        candle_1h["h"] = message_json["p"]
-
-                    if message_json["p"] < candle_1h["l"]:
-                        candle_1h["l"] = message_json["p"]
-
-                    # Sum volume
-                    candle_1h["v"] += float(message_json["q"])
-
-                # Uncomment this to see the candle forming
-                # print(candle_1h)
+            except (
+                websocket.WebSocketException,
+                ConnectionError,
+                OSError,
+            ) as err:
+                if self.stop_event.is_set():
+                    break
+                attempt += 1
+                if attempt > self._max_reconnect_attempts:
+                    print(f"Max reconnect attempts ({self._max_reconnect_attempts}) reached. Giving up.")
+                    self.running = False
+                    self.stop_event.set()
+                    break
+                delay = self._reconnect_base_delay * (2 ** (attempt - 1))
+                print(f"Connection lost ({err}). Reconnecting in {delay:.1f}s (attempt {attempt}/{self._max_reconnect_attempts})...")
+                self.stop_event.wait(delay)
 
         # Close the WebSocket connection
-        self.ws.close()
+        if self.ws is not None:
+            try:
+                self.ws.close()
+            except Exception:
+                pass
+
+    def _update_candle(self, candle, message_json, interval_name, granularity):
+        if "t" in message_json:
+            candle_date = self._floor_to_nearest_interval(message_json["t"], interval_name)
+
+            if "t" in candle and (candle_date != candle["t"]):
+                print(candle)
+                candle.clear()
+
+            candle["t"] = candle_date
+
+        if "s" in message_json:
+            candle["m"] = message_json["s"]
+            candle["g"] = granularity
+
+        if "p" in message_json and "o" not in candle:
+            candle["o"] = message_json["p"]
+            candle["h"] = message_json["p"]
+            candle["l"] = message_json["p"]
+            candle["c"] = message_json["p"]
+            if "q" in message_json:
+                candle["v"] = float(message_json["q"])
+        elif "p" in message_json and "o" in candle:
+            candle["c"] = message_json["p"]
+            if message_json["p"] > candle["h"]:
+                candle["h"] = message_json["p"]
+            if message_json["p"] < candle["l"]:
+                candle["l"] = message_json["p"]
+            candle["v"] += float(message_json["q"])
 
     def _keepalive(self, interval=30):
-        if (self.ws is not None) and (hasattr(self.ws, "connected")):
-            while self.ws.connected:
-                self.ws.ping("keepalive")
-                time.sleep(interval)
+        while not self.stop_event.is_set():
+            self.stop_event.wait(interval)
+            if self.stop_event.is_set():
+                break
+            if self.ws is not None and hasattr(self.ws, "connected") and self.ws.connected:
+                try:
+                    self.ws.ping("keepalive")
+                except Exception:
+                    pass
 
     def start(self):
         self.thread = threading.Thread(target=self._collect_data)
@@ -259,8 +233,13 @@ class WebSocketClient:
 
     def stop(self):
         self.stop_event.set()
-        self.thread.join()
-        self.keepalive.join()
+        if self.ws is not None:
+            try:
+                self.ws.close()
+            except Exception:
+                pass
+        self.thread.join(timeout=5.0)
+        self.keepalive.join(timeout=5.0)
 
     def get_data(self):
         return self.data_list

--- a/tests/test_apiclient_errors.py
+++ b/tests/test_apiclient_errors.py
@@ -1,0 +1,83 @@
+"""Tests for APIClient._rest_get error propagation."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from requests import ConnectionError as RequestsConnectionError, Timeout as RequestsTimeout
+
+from eodhd.apiclient import APIClient
+from eodhd.errors import EODHDHTTPError, EODHDConnectionError, EODHDTimeoutError
+
+
+@pytest.fixture
+def client():
+    with patch("eodhd.apiclient.requests.Session") as MockSession:
+        mock_session = MagicMock()
+        MockSession.return_value = mock_session
+        c = APIClient(api_key="demo1234567890123456")
+        c._mock_session = mock_session
+        yield c
+
+
+def test_rest_get_raises_http_error(client):
+    resp = MagicMock()
+    resp.status_code = 403
+    resp.text = '{"message":"forbidden"}'
+    resp.json.return_value = {"message": "forbidden"}
+    client._mock_session.get.return_value = resp
+
+    with pytest.raises(EODHDHTTPError) as exc_info:
+        client._rest_get(endpoint="test")
+
+    assert exc_info.value.status_code == 403
+
+
+def test_rest_get_raises_connection_error(client):
+    client._mock_session.get.side_effect = RequestsConnectionError("refused")
+
+    with pytest.raises(EODHDConnectionError):
+        client._rest_get(endpoint="test")
+
+
+def test_rest_get_raises_timeout_error(client):
+    client._mock_session.get.side_effect = RequestsTimeout("timed out")
+
+    with pytest.raises(EODHDTimeoutError):
+        client._rest_get(endpoint="test")
+
+
+def test_rest_get_success_list(client):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = [{"symbol": "AAPL", "close": 150}]
+    client._mock_session.get.return_value = resp
+
+    df = client._rest_get(endpoint="test")
+    assert len(df) == 1
+    assert "symbol" in df.columns
+
+
+def test_rest_get_success_dict(client):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"symbol": "AAPL", "close": 150}
+    client._mock_session.get.return_value = resp
+
+    df = client._rest_get(endpoint="test")
+    assert len(df) == 1
+
+
+def test_context_manager():
+    with patch("eodhd.apiclient.requests.Session") as MockSession:
+        mock_session = MagicMock()
+        MockSession.return_value = mock_session
+
+        with APIClient(api_key="demo1234567890123456") as client:
+            assert client is not None
+
+        mock_session.close.assert_called_once()
+
+
+def test_custom_timeout():
+    with patch("eodhd.apiclient.requests.Session"):
+        client = APIClient(api_key="demo1234567890123456", timeout=(1.0, 5.0))
+        assert client._timeout == (1.0, 5.0)

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -1,0 +1,89 @@
+"""Tests for BaseAPI session, timeout, and error raising."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from requests import ConnectionError as RequestsConnectionError, Timeout as RequestsTimeout
+
+from eodhd.APIs.BaseAPI import BaseAPI
+from eodhd.errors import EODHDHTTPError, EODHDConnectionError, EODHDTimeoutError
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock()
+
+
+def test_uses_session_when_provided(mock_session):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = [{"a": 1}]
+    mock_session.get.return_value = resp
+
+    api = BaseAPI(session=mock_session, timeout=(3.0, 10.0))
+    result = api._rest_get_method(api_key="demo1234567890123456", endpoint="test", uri="X")
+
+    mock_session.get.assert_called_once()
+    assert result == [{"a": 1}]
+
+
+def test_raises_http_error_on_4xx(mock_session):
+    resp = MagicMock()
+    resp.status_code = 404
+    resp.text = '{"message":"not found"}'
+    resp.json.return_value = {"message": "not found"}
+    mock_session.get.return_value = resp
+
+    api = BaseAPI(session=mock_session)
+    with pytest.raises(EODHDHTTPError) as exc_info:
+        api._rest_get_method(api_key="demo1234567890123456", endpoint="test")
+
+    assert exc_info.value.status_code == 404
+
+
+def test_raises_http_error_on_5xx(mock_session):
+    resp = MagicMock()
+    resp.status_code = 500
+    resp.text = "Internal Server Error"
+    resp.json.side_effect = ValueError("no json")
+    mock_session.get.return_value = resp
+
+    api = BaseAPI(session=mock_session)
+    with pytest.raises(EODHDHTTPError) as exc_info:
+        api._rest_get_method(api_key="demo1234567890123456", endpoint="test")
+
+    assert exc_info.value.status_code == 500
+
+
+def test_raises_connection_error(mock_session):
+    mock_session.get.side_effect = RequestsConnectionError("refused")
+
+    api = BaseAPI(session=mock_session)
+    with pytest.raises(EODHDConnectionError):
+        api._rest_get_method(api_key="demo1234567890123456", endpoint="test")
+
+
+def test_raises_timeout_error(mock_session):
+    mock_session.get.side_effect = RequestsTimeout("timed out")
+
+    api = BaseAPI(session=mock_session)
+    with pytest.raises(EODHDTimeoutError):
+        api._rest_get_method(api_key="demo1234567890123456", endpoint="test")
+
+
+def test_default_timeout():
+    api = BaseAPI()
+    assert api._timeout == (5.0, 30.0)
+
+
+def test_falls_back_to_bare_requests_without_session():
+    with patch("eodhd.APIs.BaseAPI.requests.get") as mock_get:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"ok": True}
+        mock_get.return_value = resp
+
+        api = BaseAPI()
+        result = api._rest_get_method(api_key="demo1234567890123456", endpoint="test")
+
+        mock_get.assert_called_once()
+        assert result == {"ok": True}

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,33 @@
+"""Tests for eodhd.errors hierarchy."""
+
+import pytest
+from eodhd.errors import EODHDError, EODHDHTTPError, EODHDConnectionError, EODHDTimeoutError
+
+
+def test_hierarchy():
+    assert issubclass(EODHDHTTPError, EODHDError)
+    assert issubclass(EODHDConnectionError, EODHDError)
+    assert issubclass(EODHDTimeoutError, EODHDError)
+
+
+def test_http_error_attributes():
+    err = EODHDHTTPError(status_code=404, response_body='{"message":"not found"}', message="Not Found")
+    assert err.status_code == 404
+    assert err.response_body == '{"message":"not found"}'
+    assert err.message == "Not Found"
+    assert str(err) == "Not Found"
+
+
+def test_http_error_default_message():
+    err = EODHDHTTPError(status_code=500, response_body="")
+    assert err.message == "HTTP 500"
+
+
+def test_catch_all():
+    """All EODHD errors can be caught with EODHDError."""
+    for exc_cls in (EODHDHTTPError, EODHDConnectionError, EODHDTimeoutError):
+        with pytest.raises(EODHDError):
+            if exc_cls is EODHDHTTPError:
+                raise exc_cls(status_code=500, response_body="err")
+            else:
+                raise exc_cls("something went wrong")


### PR DESCRIPTION
## Summary

Fixes 5 CRITICAL issues found in [code review](../docs/reports/2026-03-05-python-sdk-code-review.md) — all cause silent data loss or hangs in production.

- **C1 — Silent error swallowing**: `BaseAPI._rest_get_method()` and `APIClient._rest_get()` now raise `EODHDHTTPError` / `EODHDConnectionError` / `EODHDTimeoutError` instead of returning `{}` / empty DataFrame
- **C2 — No request timeouts**: Default `(5s connect, 30s read)` timeout on all HTTP calls
- **C3 — No connection pooling**: `APIClient` creates a shared `requests.Session`, passed to all 35 API subclass instantiations
- **C4 — WebSocket never reconnects**: Reconnect loop with exponential backoff (max 5 attempts), candle state resets on reconnect
- **C5 — Signal handler deadlock**: Removed `thread.join()` from signal handler, fixed `stop()` to close WS first (unblocks `recv()`), then join with timeout

### New files
- `eodhd/errors.py` — 4-class error hierarchy (`EODHDError` base)
- `tests/test_errors.py`, `tests/test_baseapi.py`, `tests/test_apiclient_errors.py` — 18 new tests

### Backward compatibility
- `APIClient(api_key)` still works (timeout has default)
- `BaseAPI()` still works standalone (falls back to bare `requests.get`)
- Context manager added: `with APIClient(key) as client:`
- All errors subclass `EODHDError` for catch-all

## Test plan
- [x] `pytest tests/ -v` — 23/23 pass
- [x] `from eodhd import APIClient, EODHDError, EODHDHTTPError` — imports OK
- [x] `from eodhd import WebSocketClient` — imports OK
- [ ] Manual smoke test against live API
