### PR TITLE
feat: add Fundamentals API v1.1 method

### DIFF
--- a/eodhd/APIs/FundamentalDataAPI.py
+++ b/eodhd/APIs/FundamentalDataAPI.py
@@ -12,3 +12,11 @@ class FundamentalDataAPI(BaseAPI):
             raise ValueError("Ticker is empty. You need to add ticker to args")
 
         return self._rest_get_method(api_key=api_token, endpoint=endpoint, uri=ticker)
+
+    def get_fundamentals_data_v1_1(self, api_token: str, ticker: str):
+        endpoint = 'v1.1/fundamentals'
+
+        if ticker.strip() == "" or ticker is None:
+            raise ValueError("Ticker is empty. You need to add ticker to args")
+
+        return self._rest_get_method(api_key=api_token, endpoint=endpoint, uri=ticker)

--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -691,6 +691,16 @@ class APIClient:
         api_call = FundamentalDataAPI()
         return api_call.get_fundamentals_data(api_token=self._api_key, ticker=ticker)
 
+    def get_fundamentals_data_v1_1(self, ticker: str) -> list:
+        """Available args:
+        ticker (required) - consists of two parts: [SYMBOL_NAME].[EXCHANGE_ID]. Example: AAPL.US
+        For more information visit: https://eodhistoricaldata.com/financial-apis/stock-etfs-fundamental-data-feeds/
+        Uses v1.1 endpoint with improved Earnings::Trend data.
+        """
+
+        api_call = FundamentalDataAPI()
+        return api_call.get_fundamentals_data_v1_1(api_token=self._api_key, ticker=ticker)
+
     def get_eod_splits_dividends_data(self, country="US", type=None, date=None, symbols=None, filter=None) -> list:
         """Available args:
         type (not required) - can get splits, empty or dividends.

--- a/tests/test_fundamentaldataapi.py
+++ b/tests/test_fundamentaldataapi.py
@@ -1,0 +1,27 @@
+"""Unit tests for FundamentalDataAPI"""
+
+import pytest
+from eodhd.APIs import FundamentalDataAPI
+
+
+def test_get_fundamentals_data_empty_ticker():
+    """Ticker is empty"""
+    api = FundamentalDataAPI()
+    with pytest.raises(ValueError) as execinfo:
+        api.get_fundamentals_data(api_token="test", ticker="")
+    assert str(execinfo.value) == "Ticker is empty. You need to add ticker to args"
+
+
+def test_get_fundamentals_data_v1_1_empty_ticker():
+    """Ticker is empty for v1.1"""
+    api = FundamentalDataAPI()
+    with pytest.raises(ValueError) as execinfo:
+        api.get_fundamentals_data_v1_1(api_token="test", ticker="")
+    assert str(execinfo.value) == "Ticker is empty. You need to add ticker to args"
+
+
+def test_get_fundamentals_data_v1_1_method_exists():
+    """v1.1 method exists on FundamentalDataAPI"""
+    api = FundamentalDataAPI()
+    assert hasattr(api, "get_fundamentals_data_v1_1")
+    assert callable(api.get_fundamentals_data_v1_1)


### PR DESCRIPTION
## Summary
- Added `get_fundamentals_data_v1_1()` to `FundamentalDataAPI` and `APIClient`
- Same params as v1 — only the URL path differs (`/v1.1/fundamentals/`)
- 3 new tests, all 8 tests pass

## Test plan
- [x] `pytest` — 8 passed
- [ ] Smoke test with real API token
