### PR TITLE
fix: add missing params + v1.1 bulk fundamentals

### DIFF
--- a/eodhd/APIs/BulkFundamentalsAPI.py
+++ b/eodhd/APIs/BulkFundamentalsAPI.py
@@ -52,3 +52,47 @@ class BulkFundamentalsAPI(BaseAPI):
             uri=uri,
             querystring=querystring,
         )
+
+    def get_bulk_fundamentals_v1_1(self, api_token: str, exchange: str, symbols: str = None,
+                                    offset: int = None, limit: int = None):
+        """
+        Get fundamental data in bulk for an entire exchange (v1.1).
+
+        Parameters
+        ----------
+        api_token : str
+            Your EODHD API token.
+        exchange : str
+            Exchange code, e.g. "US".
+        symbols : str, optional
+            Comma-separated list of tickers to filter, e.g. "AAPL,MSFT".
+        offset : int, optional
+            Pagination offset.
+        limit : int, optional
+            Maximum number of results.
+
+        Returns
+        -------
+        list[dict] or dict
+            Bulk fundamentals data.
+        """
+        if not exchange or not isinstance(exchange, str) or exchange.strip() == "":
+            raise ValueError("Parameter 'exchange' is required and must be a non-empty string.")
+
+        endpoint = "v1.1/bulk-fundamentals"
+        uri = exchange.strip()
+        querystring = ""
+
+        if symbols is not None:
+            querystring += f"&symbols={symbols}"
+        if offset is not None:
+            querystring += f"&offset={int(offset)}"
+        if limit is not None:
+            querystring += f"&limit={int(limit)}"
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint=endpoint,
+            uri=uri,
+            querystring=querystring,
+        )

--- a/eodhd/APIs/FundamentalDataAPI.py
+++ b/eodhd/APIs/FundamentalDataAPI.py
@@ -5,18 +5,50 @@ from .BaseAPI import BaseAPI
 
 class FundamentalDataAPI(BaseAPI):
 
-    def get_fundamentals_data(self, api_token: str, ticker: str):
+    def get_fundamentals_data(self, api_token: str, ticker: str, filter: str = None,
+                              historical: int = None, from_date: str = None, to_date: str = None,
+                              version: int = None, no_cache: int = None):
         endpoint = 'fundamentals'
 
-        if ticker.strip() == "" or ticker is None:
+        if ticker is None or ticker.strip() == "":
             raise ValueError("Ticker is empty. You need to add ticker to args")
 
-        return self._rest_get_method(api_key=api_token, endpoint=endpoint, uri=ticker)
+        querystring = ""
+        if filter is not None:
+            querystring += f"&filter={filter}"
+        if historical is not None:
+            querystring += f"&historical={int(historical)}"
+        if from_date is not None:
+            querystring += f"&from={from_date}"
+        if to_date is not None:
+            querystring += f"&to={to_date}"
+        if version is not None:
+            querystring += f"&version={int(version)}"
+        if no_cache is not None:
+            querystring += f"&no_cache={int(no_cache)}"
 
-    def get_fundamentals_data_v1_1(self, api_token: str, ticker: str):
+        return self._rest_get_method(api_key=api_token, endpoint=endpoint, uri=ticker, querystring=querystring)
+
+    def get_fundamentals_data_v1_1(self, api_token: str, ticker: str, filter: str = None,
+                                    historical: int = None, from_date: str = None, to_date: str = None,
+                                    version: int = None, no_cache: int = None):
         endpoint = 'v1.1/fundamentals'
 
-        if ticker.strip() == "" or ticker is None:
+        if ticker is None or ticker.strip() == "":
             raise ValueError("Ticker is empty. You need to add ticker to args")
 
-        return self._rest_get_method(api_key=api_token, endpoint=endpoint, uri=ticker)
+        querystring = ""
+        if filter is not None:
+            querystring += f"&filter={filter}"
+        if historical is not None:
+            querystring += f"&historical={int(historical)}"
+        if from_date is not None:
+            querystring += f"&from={from_date}"
+        if to_date is not None:
+            querystring += f"&to={to_date}"
+        if version is not None:
+            querystring += f"&version={int(version)}"
+        if no_cache is not None:
+            querystring += f"&no_cache={int(no_cache)}"
+
+        return self._rest_get_method(api_key=api_token, endpoint=endpoint, uri=ticker, querystring=querystring)

--- a/eodhd/APIs/IntradayDataAPI.py
+++ b/eodhd/APIs/IntradayDataAPI.py
@@ -8,14 +8,14 @@ class IntradayDataAPI(BaseAPI):
     def get_intraday_historical_data(self, api_token: str, symbol: str, interval: str,
                                      from_unix_time: str = None, to_unix_time: str = None):
 
-        possible_intervals = ['5m', '1h', '1m']
+        possible_intervals = ['1m', '5m', '15m', '30m', '1h']
 
         endpoint = 'intraday'
 
         if symbol.strip() == "" or symbol is None:
             raise ValueError("Ticker is empty. You need to add ticker to args")
         if interval not in possible_intervals:
-            raise ValueError("Interval must be in ['5m', '1h', '1m'] values")
+            raise ValueError("Interval must be in ['1m', '5m', '15m', '30m', '1h'] values")
 
         uri = f'{symbol}'
         query_string = ''

--- a/eodhd/APIs/SearchAPI.py
+++ b/eodhd/APIs/SearchAPI.py
@@ -10,7 +10,8 @@ class SearchAPI(BaseAPI):
         GET /api/search/{query}
     """
 
-    def search(self, api_token: str, query: str, limit: int = None):
+    def search(self, api_token: str, query: str, limit: int = None,
+               type: str = None, exchange: str = None, bonds_only: int = None):
         """
         Search for stocks, ETFs, mutual funds, indices, and cryptocurrencies.
 
@@ -22,6 +23,12 @@ class SearchAPI(BaseAPI):
             Search query (company name, ticker, ISIN).
         limit : int, optional
             Maximum number of results to return.
+        type : str, optional
+            Filter by instrument type.
+        exchange : str, optional
+            Filter by exchange code.
+        bonds_only : int, optional
+            Set to 1 to return only bonds.
 
         Returns
         -------
@@ -37,6 +44,12 @@ class SearchAPI(BaseAPI):
 
         if limit is not None:
             querystring += f"&limit={int(limit)}"
+        if type is not None:
+            querystring += f"&type={type}"
+        if exchange is not None:
+            querystring += f"&exchange={exchange}"
+        if bonds_only is not None:
+            querystring += f"&bonds_only={int(bonds_only)}"
 
         return self._rest_get_method(
             api_key=api_token,

--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -703,24 +703,25 @@ class APIClient:
             limit=limit,
         )
 
-    def get_fundamentals_data(self, ticker: str) -> list:
-        """Available args:
-        ticker (required) - consists of two parts: [SYMBOL_NAME].[EXCHANGE_ID]. Example: AAPL.US
-        For more information visit: https://eodhistoricaldata.com/financial-apis/stock-etfs-fundamental-data-feeds/
-        """
-
+    def get_fundamentals_data(self, ticker: str, filter: str = None, historical: int = None,
+                              from_date: str = None, to_date: str = None, version: int = None,
+                              no_cache: int = None) -> list:
+        """GET /api/fundamentals/{ticker}"""
         api_call = FundamentalDataAPI(session=self._session, timeout=self._timeout)
-        return api_call.get_fundamentals_data(api_token=self._api_key, ticker=ticker)
+        return api_call.get_fundamentals_data(
+            api_token=self._api_key, ticker=ticker, filter=filter, historical=historical,
+            from_date=from_date, to_date=to_date, version=version, no_cache=no_cache,
+        )
 
-    def get_fundamentals_data_v1_1(self, ticker: str) -> list:
-        """Available args:
-        ticker (required) - consists of two parts: [SYMBOL_NAME].[EXCHANGE_ID]. Example: AAPL.US
-        For more information visit: https://eodhistoricaldata.com/financial-apis/stock-etfs-fundamental-data-feeds/
-        Uses v1.1 endpoint with improved Earnings::Trend data.
-        """
-
-        api_call = FundamentalDataAPI()
-        return api_call.get_fundamentals_data_v1_1(api_token=self._api_key, ticker=ticker)
+    def get_fundamentals_data_v1_1(self, ticker: str, filter: str = None, historical: int = None,
+                                    from_date: str = None, to_date: str = None, version: int = None,
+                                    no_cache: int = None) -> list:
+        """GET /api/v1.1/fundamentals/{ticker} — uses improved Earnings::Trend data"""
+        api_call = FundamentalDataAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_fundamentals_data_v1_1(
+            api_token=self._api_key, ticker=ticker, filter=filter, historical=historical,
+            from_date=from_date, to_date=to_date, version=version, no_cache=no_cache,
+        )
 
     def get_eod_splits_dividends_data(self, country="US", type=None, date=None, symbols=None, filter=None) -> list:
         """Available args:
@@ -1437,17 +1438,13 @@ class APIClient:
 
     # ── Phase 1: Core Parity ──────────────────────────────────────
 
-    def search(self, query, limit=None):
-        """
-        Search API
-        Endpoint: GET /api/search/{query}
-
-        Args:
-            query [REQUIRED] - Search query (company name, ticker, ISIN)
-            limit [OPTIONAL] - Maximum number of results
-        """
+    def search(self, query, limit=None, type=None, exchange=None, bonds_only=None):
+        """GET /api/search/{query}"""
         api_call = SearchAPI(session=self._session, timeout=self._timeout)
-        return api_call.search(api_token=self._api_key, query=query, limit=limit)
+        return api_call.search(
+            api_token=self._api_key, query=query, limit=limit,
+            type=type, exchange=exchange, bonds_only=bonds_only,
+        )
 
     def get_logo(self, symbol):
         """
@@ -1492,6 +1489,13 @@ class APIClient:
         """
         api_call = BulkFundamentalsAPI(session=self._session, timeout=self._timeout)
         return api_call.get_bulk_fundamentals(
+            api_token=self._api_key, exchange=exchange, symbols=symbols, offset=offset, limit=limit,
+        )
+
+    def get_bulk_fundamentals_v1_1(self, exchange, symbols=None, offset=None, limit=None):
+        """GET /api/v1.1/bulk-fundamentals/{exchange}"""
+        api_call = BulkFundamentalsAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_bulk_fundamentals_v1_1(
             api_token=self._api_key, exchange=exchange, symbols=symbols, offset=offset, limit=limit,
         )
 


### PR DESCRIPTION
## Summary
- Fix bug: `get_fundamentals_data_v1_1()` wasn't passing session/timeout to FundamentalDataAPI
- Add `get_bulk_fundamentals_v1_1()` method (v1.1/bulk-fundamentals endpoint)
- Add filter, historical, from_date, to_date, version, no_cache params to fundamentals (v1 + v1.1)
- Add type, exchange, bonds_only params to search
- Add 15m, 30m intervals to intraday

## Test plan
- [x] `python3 -m pytest tests/ -v` — 57 tests pass
- [x] All new endpoints verified against live API
