### PR TITLE
feat: Exchange Details API v2 support

### DIFF
--- a/eodhd/APIs/ExchangeDetailsV2API.py
+++ b/eodhd/APIs/ExchangeDetailsV2API.py
@@ -1,0 +1,32 @@
+# APIs/ExchangeDetailsV2API.py
+
+from .BaseAPI import BaseAPI
+
+
+class ExchangeDetailsV2API(BaseAPI):
+
+    def get_exchange_details_v2_list(self, api_token: str):
+        """Get list of all supported exchanges with basic details (v2).
+
+        Returns a list of exchange objects with codes and metadata.
+        Endpoint: GET /v2/exchange-details
+        """
+        endpoint = 'v2/exchange-details'
+
+        return self._rest_get_method(api_key=api_token, endpoint=endpoint)
+
+    def get_exchange_details_v2(self, api_token: str, code: str):
+        """Get detailed information for a specific exchange (v2).
+
+        Includes trading hours, holidays, and early close schedules.
+
+        Parameters:
+            api_token: EODHD API token
+            code: Exchange code (e.g. 'US', 'LSE', 'TO')
+
+        Endpoint: GET /v2/exchange-details/{code}
+        """
+        endpoint = 'v2/exchange-details'
+        uri = f'{code}'
+
+        return self._rest_get_method(api_key=api_token, endpoint=endpoint, uri=uri)

--- a/eodhd/APIs/__init__.py
+++ b/eodhd/APIs/__init__.py
@@ -33,6 +33,7 @@ from .LogoAPI import LogoAPI
 from .UserAPI import UserAPI
 from .BulkFundamentalsAPI import BulkFundamentalsAPI
 from .TreasuryAPI import TreasuryAPI
+from .ExchangeDetailsV2API import ExchangeDetailsV2API
 
 #Marketplace endpoints
 from .MPIndexComponentsAPI import MPIndexComponentsAPI

--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -49,6 +49,7 @@ from eodhd.APIs import LogoAPI
 from eodhd.APIs import UserAPI
 from eodhd.APIs import BulkFundamentalsAPI
 from eodhd.APIs import TreasuryAPI
+from eodhd.APIs import ExchangeDetailsV2API
 
 #Marketplace endpoints
 from eodhd.APIs import MPIndexComponentsAPI
@@ -927,6 +928,29 @@ class APIClient:
         """
         api_call = TradingHours_StockMarketHolidays_SymbolsChangeHistoryAPI(session=self._session, timeout=self._timeout)
         return api_call.symbol_change_history(api_token=self._api_key, from_date=from_date, to_date=to_date)
+
+    def get_exchange_details_v2_list(self):
+        """Get list of all supported exchanges with basic details (v2).
+
+        Returns parsed JSON (list of dicts).
+        Endpoint: GET /api/v2/exchange-details
+        For more information visit: https://eodhd.com/financial-apis/exchanges-api-trading-hours-and-stock-market-holidays/
+        """
+        api_call = ExchangeDetailsV2API(session=self._session, timeout=self._timeout)
+        return api_call.get_exchange_details_v2_list(api_token=self._api_key)
+
+    def get_exchange_details_v2(self, code: str):
+        """Get detailed exchange information including trading hours, holidays, and early close (v2).
+
+        Parameters:
+            code: Exchange code (e.g. 'US', 'LSE', 'TO')
+
+        Returns parsed JSON (dict).
+        Endpoint: GET /api/v2/exchange-details/{code}
+        For more information visit: https://eodhd.com/financial-apis/exchanges-api-trading-hours-and-stock-market-holidays/
+        """
+        api_call = ExchangeDetailsV2API(session=self._session, timeout=self._timeout)
+        return api_call.get_exchange_details_v2(api_token=self._api_key, code=code)
 
     def stock_market_screener(self, sort=None, filters=None, limit=None, signals=None, offset=None):
         """Available args:

--- a/tests/test_exchange_details_v2.py
+++ b/tests/test_exchange_details_v2.py
@@ -1,0 +1,131 @@
+"""Tests for ExchangeDetailsV2API."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from eodhd.APIs.ExchangeDetailsV2API import ExchangeDetailsV2API
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock()
+
+
+def _make_api(session):
+    return ExchangeDetailsV2API(session=session)
+
+
+def _mock_response(session, data=None):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = data or []
+    session.get.return_value = resp
+
+
+# --- List endpoint tests ---
+
+def test_list_constructs_correct_url(mock_session):
+    _mock_response(mock_session, data=[{"Code": "US", "Name": "US Exchanges"}])
+    api = _make_api(mock_session)
+    result = api.get_exchange_details_v2_list(api_token="test1234567890123456")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/v2/exchange-details/" in call_url
+    assert "api_token=test1234567890123456" in call_url
+    assert result == [{"Code": "US", "Name": "US Exchanges"}]
+
+
+def test_list_returns_list(mock_session):
+    exchanges = [
+        {"Code": "US", "Name": "US Exchanges"},
+        {"Code": "LSE", "Name": "London Stock Exchange"},
+    ]
+    _mock_response(mock_session, data=exchanges)
+    api = _make_api(mock_session)
+    result = api.get_exchange_details_v2_list(api_token="test1234567890123456")
+
+    assert len(result) == 2
+    assert result[0]["Code"] == "US"
+    assert result[1]["Code"] == "LSE"
+
+
+# --- Single exchange endpoint tests ---
+
+def test_single_constructs_correct_url(mock_session):
+    detail = {"Code": "US", "Name": "US Exchanges", "TradingHours": {}}
+    _mock_response(mock_session, data=detail)
+    api = _make_api(mock_session)
+    result = api.get_exchange_details_v2(api_token="test1234567890123456", code="US")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/v2/exchange-details/US" in call_url
+    assert "api_token=test1234567890123456" in call_url
+    assert result == detail
+
+
+def test_single_different_code(mock_session):
+    detail = {"Code": "LSE", "Name": "London Stock Exchange"}
+    _mock_response(mock_session, data=detail)
+    api = _make_api(mock_session)
+    result = api.get_exchange_details_v2(api_token="test1234567890123456", code="LSE")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/v2/exchange-details/LSE" in call_url
+    assert result["Code"] == "LSE"
+
+
+def test_single_returns_dict(mock_session):
+    detail = {
+        "Code": "TO",
+        "Name": "Toronto Stock Exchange",
+        "TradingHours": {"open": "09:30", "close": "16:00"},
+        "Holidays": ["2026-01-01", "2026-07-01"],
+    }
+    _mock_response(mock_session, data=detail)
+    api = _make_api(mock_session)
+    result = api.get_exchange_details_v2(api_token="test1234567890123456", code="TO")
+
+    assert isinstance(result, dict)
+    assert result["Code"] == "TO"
+    assert "TradingHours" in result
+    assert "Holidays" in result
+
+
+# --- Error handling tests ---
+
+def test_list_http_error(mock_session):
+    from eodhd.errors import EODHDHTTPError
+
+    resp = MagicMock()
+    resp.status_code = 401
+    resp.text = "Unauthorized"
+    resp.json.return_value = {"message": "Invalid API token"}
+    mock_session.get.return_value = resp
+
+    api = _make_api(mock_session)
+    with pytest.raises(EODHDHTTPError):
+        api.get_exchange_details_v2_list(api_token="bad_token")
+
+
+def test_single_http_error(mock_session):
+    from eodhd.errors import EODHDHTTPError
+
+    resp = MagicMock()
+    resp.status_code = 404
+    resp.text = "Not Found"
+    resp.json.return_value = {"message": "Exchange not found"}
+    mock_session.get.return_value = resp
+
+    api = _make_api(mock_session)
+    with pytest.raises(EODHDHTTPError):
+        api.get_exchange_details_v2(api_token="test1234567890123456", code="INVALID")
+
+
+def test_url_has_fmt_json(mock_session):
+    """Verify fmt=json query parameter is included in the URL."""
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_exchange_details_v2_list(api_token="test1234567890123456")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "fmt=json" in call_url


### PR DESCRIPTION
## Summary
- Added ExchangeDetailsV2API class with two methods
- Facade methods get_exchange_details_v2_list() and get_exchange_details_v2(code)
- 8 new pytest tests

## Test plan
- [x] 65 pytest tests passed (+8 new)
- [x] No import errors