### PR TITLE
fix: handle free-tier 'warning' column in get_historical_data (#66)

### DIFF
--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -186,6 +186,18 @@ class APIClient:
         else:
             return pd.DataFrame(json_data, index=[0])
 
+    def _strip_free_tier_warning(self, df_data: pd.DataFrame) -> pd.DataFrame:
+        """Free API keys append a 'warning' column (e.g. data limited to one year)
+        to historical responses. Surface the message and drop the column so the
+        downstream fixed-width column relabelling does not raise a confusing
+        "Length mismatch" pandas error (see issue #66)."""
+        if "warning" in df_data.columns:
+            messages = df_data["warning"].dropna()
+            if not messages.empty:
+                self.console.log("EODHD API warning:", messages.iloc[-1])
+            df_data = df_data.drop(columns=["warning"])
+        return df_data
+
     def get_exchanges(self) -> pd.DataFrame:
         """Get supported exchanges"""
 
@@ -313,6 +325,7 @@ class APIClient:
                     sys.exit()
 
             df_data = self._rest_get("eod", symbol, f"&period={interval}&from={str(date_from)}&to={str(date_to)}")
+            df_data = self._strip_free_tier_warning(df_data)
 
             if len(df_data) == 0:
                 columns_eod = [
@@ -424,6 +437,7 @@ class APIClient:
                     sys.exit()
 
             df_data = self._rest_get("intraday", symbol, f"&interval={interval}&from={str(date_from)}&to={str(date_to)}")
+            df_data = self._strip_free_tier_warning(df_data)
 
             if len(df_data) == 0:
                 columns_eod = [

--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -196,6 +196,12 @@ class APIClient:
             if not messages.empty:
                 self.console.log("EODHD API warning:", messages.iloc[-1])
             df_data = df_data.drop(columns=["warning"])
+            # Degenerate case: the response carried only the 'warning' column and
+            # no market data. Dropping it leaves a column-less frame; return it
+            # empty (0 rows) so the caller's `len(df_data) == 0` guard handles it
+            # instead of crashing later on a missing date/OHLCV column (#66).
+            if df_data.shape[1] == 0:
+                return df_data.iloc[0:0]
         return df_data
 
     def get_exchanges(self) -> pd.DataFrame:

--- a/tests/test_historical_free_tier_warning.py
+++ b/tests/test_historical_free_tier_warning.py
@@ -1,0 +1,65 @@
+"""Regression test for issue #66.
+
+A free API key requesting more than one year of historical data gets an extra
+'warning' column appended to the response. The fixed-width column relabelling in
+get_historical_data then raised a confusing pandas "Length mismatch" error.
+The warning must be surfaced and the column dropped instead.
+"""
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from eodhd.apiclient import APIClient
+
+
+@pytest.fixture
+def client():
+    with patch("eodhd.apiclient.requests.Session"):
+        yield APIClient(api_key="demo1234567890123456")
+
+
+def _free_tier_eod_frame():
+    """Mimics the EOD response a free key returns for a >1y request: a trailing
+    'warning' column that is NaN on every row except the last."""
+    return pd.DataFrame(
+        {
+            "date": ["2025-04-22", "2025-04-23"],
+            "open": [14347.8896, 14404.0498],
+            "high": [14414.0996, 14645.2598],
+            "low": [14293.0303, 14403.5498],
+            "close": [14404.0498, 14549.4199],
+            "adjusted_close": [14404.0498, 14549.4199],
+            "volume": [0, 0],
+            "warning": [None, "Data is limited by one year as you have free subscription."],
+        }
+    )
+
+
+def test_free_tier_warning_does_not_raise(client):
+    with patch.object(client, "_rest_get", return_value=_free_tier_eod_frame()):
+        df = client.get_historical_data("BUKAC.INDX", interval="d", results=10000)
+
+    # Previously raised: ValueError: Length mismatch: Expected axis has 9 elements...
+    assert "warning" not in df.columns
+    assert list(df.columns) == [
+        "symbol",
+        "interval",
+        "open",
+        "high",
+        "low",
+        "close",
+        "adjusted_close",
+        "volume",
+    ]
+    assert len(df) == 2
+
+
+def test_free_tier_warning_is_logged(client):
+    with patch.object(client, "_rest_get", return_value=_free_tier_eod_frame()):
+        with patch.object(client.console, "log") as mock_log:
+            client.get_historical_data("BUKAC.INDX", interval="d", results=10000)
+
+    logged = " ".join(str(a) for call in mock_log.call_args_list for a in call.args)
+    assert "warning" in logged.lower()

--- a/tests/test_historical_free_tier_warning.py
+++ b/tests/test_historical_free_tier_warning.py
@@ -63,3 +63,60 @@ def test_free_tier_warning_is_logged(client):
 
     logged = " ".join(str(a) for call in mock_log.call_args_list for a in call.args)
     assert "warning" in logged.lower()
+
+
+def _free_tier_intraday_frame():
+    """Mimics the intraday response a free key returns for an over-range request:
+    the same trailing 'warning' column, on the intraday column shape
+    (timestamp/gmtoffset/datetime/OHLC/volume). Column order matters — the client
+    relabels positionally after dropping 'datetime'."""
+    return pd.DataFrame(
+        {
+            "timestamp": [1745312400, 1745316000],
+            "gmtoffset": [0, 0],
+            "datetime": ["2025-04-22 09:00:00", "2025-04-22 10:00:00"],
+            "open": [14347.8896, 14404.0498],
+            "high": [14414.0996, 14645.2598],
+            "low": [14293.0303, 14403.5498],
+            "close": [14404.0498, 14549.4199],
+            "volume": [0, 0],
+            "warning": [None, "Data is limited by one year as you have free subscription."],
+        }
+    )
+
+
+def test_free_tier_warning_intraday_does_not_raise(client):
+    """The fix is applied in BOTH the EOD and the intraday branch of
+    get_historical_data — guard the intraday branch too (#66)."""
+    with patch.object(client, "_rest_get", return_value=_free_tier_intraday_frame()):
+        df = client.get_historical_data("BUKAC.INDX", interval="1h", results=10000)
+
+    assert "warning" not in df.columns
+    assert list(df.columns) == [
+        "epoch",
+        "gmtoffset",
+        "symbol",
+        "interval",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    ]
+    assert len(df) == 2
+
+
+def _warning_only_frame():
+    """Degenerate free-tier response: a single 'warning' row and no market data
+    at all. After dropping the column the frame must be treated as empty rather
+    than crashing on a missing date/OHLCV column."""
+    return pd.DataFrame({"warning": ["Data is limited by one year as you have free subscription."]})
+
+
+def test_free_tier_warning_only_response_returns_empty(client):
+    with patch.object(client, "_rest_get", return_value=_warning_only_frame()):
+        df = client.get_historical_data("BUKAC.INDX", interval="d", results=10000)
+
+    # No crash; empty result with the standard EOD column set.
+    assert "warning" not in df.columns
+    assert len(df) == 0


### PR DESCRIPTION
Closes #66 (reported by @pjmcdermott).

A free API key requesting **more than one year** of historical data gets an extra `warning` column appended to the response (NaN on all rows except the last, which holds *"Data is limited by one year as you have free subscription."*). `get_historical_data` relabels columns by fixed position, so the extra column produced a confusing pandas error:

```
ValueError: Length mismatch: Expected axis has 9 elements, new values have 8 elements
```

## Fix
Added `_strip_free_tier_warning()` which **surfaces the API warning message** via the console and drops the `warning` column before the relabelling step. Applied right after the `_rest_get` call in both the EOD and intraday branches.

The call now returns the available (one-year) data **with a clear warning logged**, instead of crashing — which is what the reporter asked for.

## Verification
- New regression tests (`tests/test_historical_free_tier_warning.py`): reproduce the 9-column free-tier frame, assert no crash + warning logged + `warning` column dropped
- `pytest`: ✅ 67 passed
- Live API no-regression: normal `get_historical_data('AAPL.US', interval='d')` returns the expected 8 columns, no `warning` column

---

## Update

- Added an intraday regression test — the fix applies to both the EOD and intraday branches of `get_historical_data`.
- A response containing only a `warning` column and no market data is now returned as empty instead of raising on a missing date/OHLCV column.
