### PR TITLE
feat: add Credit & Sovereign Risk, Sanctions, Interest Rates APIs (14 endpoints)

### DIFF
--- a/eodhd/APIs/BaseAPI.py
+++ b/eodhd/APIs/BaseAPI.py
@@ -1,6 +1,7 @@
 # APIs/BaseAPI.py
 
 from json.decoder import JSONDecodeError
+from urllib.parse import quote
 import requests
 from requests import ConnectionError as requests_ConnectionError
 from requests import Timeout as requests_Timeout
@@ -16,6 +17,77 @@ class BaseAPI:
         self._session = session
         self._timeout = timeout
         self.console = Console()
+
+    @staticmethod
+    def _blank_to_none(value):
+        """Return None for None or a blank/whitespace-only string, else the value unchanged."""
+        if value is None:
+            return None
+        if isinstance(value, str) and value.strip() == "":
+            return None
+        return value
+
+    @staticmethod
+    def _filter(name: str, value) -> str:
+        """Build a URL-encoded &filter[name]=value fragment for deep-object filters.
+
+        None and blank/whitespace-only values are omitted (treated as "no filter"),
+        so an empty string never becomes a spurious &filter[name]= on the wire.
+        """
+        if value is None:
+            return ""
+        text = str(value).strip()
+        if text == "":
+            return ""
+        return f"&filter[{name}]={quote(text, safe='')}"
+
+    @staticmethod
+    def _param(name: str, value) -> str:
+        """Build a URL-encoded &name=value fragment for BARE query params (not filter[...]).
+
+        None and blank/whitespace-only values are omitted.
+        """
+        if value is None:
+            return ""
+        text = str(value).strip()
+        if text == "":
+            return ""
+        return f"&{name}={quote(text, safe='')}"
+
+    @staticmethod
+    def _coerce_page_int(name: str, value) -> int:
+        """Coerce a pagination value to int, rejecting bools and non-whole floats.
+
+        Accepts real ints and integer-valued strings (e.g. "10"); rejects True/False
+        and fractional floats so a request is never silently altered (e.g. 1.9 -> 1)."""
+        if isinstance(value, bool):
+            raise ValueError(f"{name} must be an integer.")
+        try:
+            ivalue = int(value)
+        except (TypeError, ValueError) as err:
+            raise ValueError(f"{name} must be an integer.") from err
+        if isinstance(value, float) and ivalue != value:
+            raise ValueError(f"{name} must be a whole number.")
+        return ivalue
+
+    @staticmethod
+    def _pagination(page_offset=None, page_limit=None) -> str:
+        """Build &page[offset]/&page[limit] fragments, validating the server's bounds
+        (offset >= 0, 1 <= limit <= 100)."""
+        query_string = ""
+        if page_offset is not None:
+            page_offset = BaseAPI._coerce_page_int("page_offset", page_offset)
+            if page_offset < 0:
+                raise ValueError("page_offset must be >= 0.")
+            query_string += f"&page[offset]={page_offset}"
+        if page_limit is not None:
+            page_limit = BaseAPI._coerce_page_int("page_limit", page_limit)
+            if page_limit < 1:
+                raise ValueError("page_limit must be >= 1.")
+            if page_limit > 100:
+                raise ValueError("page_limit must be <= 100.")
+            query_string += f"&page[limit]={page_limit}"
+        return query_string
 
     def _do_get(self, url: str):
         """Execute GET using session if available, else bare requests.get."""

--- a/eodhd/APIs/CreditSovereignRiskAPI.py
+++ b/eodhd/APIs/CreditSovereignRiskAPI.py
@@ -1,0 +1,244 @@
+# APIs/CreditSovereignRiskAPI.py
+
+from urllib.parse import quote
+
+from .BaseAPI import BaseAPI
+
+
+class CreditSovereignRiskAPI(BaseAPI):
+    """
+    Wrapper for Credit & Sovereign Risk endpoints:
+
+        GET /api/credit-risk/sovereign/risk-premium
+        GET /api/credit-risk/sovereign/credit-ratings
+        GET /api/credit-risk/sovereign/cds-spreads
+        GET /api/credit-risk/sovereign/default-spreads
+        GET /api/credit-risk/corporate/cmdi
+        GET /api/credit-risk/corporate/hqm-yields
+        GET /api/credit-risk/cds-market/aggregates
+
+    Notes:
+    - All endpoints return a JSON envelope { data, meta, links }.
+    - Filtering uses filter[...] deep-object params.
+    - Pagination uses page[offset] and page[limit].
+    """
+
+    @staticmethod
+    def _filter(name: str, value) -> str:
+        """Build a URL-encoded &filter[name]=value fragment (empty if value is None)."""
+        if value is None:
+            return ""
+        return f"&filter[{name}]={quote(str(value), safe='')}"
+
+    @staticmethod
+    def _pagination(page_offset: int = None, page_limit: int = None) -> str:
+        query_string = ""
+        if page_offset is not None:
+            page_offset = int(page_offset)
+            if page_offset < 0:
+                raise ValueError("page_offset must be >= 0.")
+            query_string += f"&page[offset]={page_offset}"
+        if page_limit is not None:
+            page_limit = int(page_limit)
+            if page_limit < 1:
+                raise ValueError("page_limit must be >= 1.")
+            query_string += f"&page[limit]={page_limit}"
+        return query_string
+
+    def get_sovereign_risk_premium(
+        self,
+        api_token: str,
+        country: str = None,
+        region: str = None,
+        as_of: str = None,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/credit-risk/sovereign/risk-premium
+
+        Fields: country_iso3, country_name, as_of_date, moodys_rating,
+        adj_default_spread, country_risk_premium, equity_risk_premium,
+        corporate_tax_rate, sovereign_cds (nullable), source.
+        """
+        query_string = ""
+        query_string += self._filter("country", country)
+        query_string += self._filter("region", region)
+        query_string += self._filter("as_of", as_of)
+        query_string += self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="credit-risk",
+            uri="sovereign/risk-premium",
+            querystring=query_string,
+        )
+
+    def get_sovereign_credit_ratings(
+        self,
+        api_token: str,
+        country: str = None,
+        as_of: str = None,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/credit-risk/sovereign/credit-ratings
+
+        Fields: country_iso3, country_name, as_of_date, moodys_rating,
+        sp_rating, fitch_rating, source.
+        """
+        query_string = ""
+        query_string += self._filter("country", country)
+        query_string += self._filter("as_of", as_of)
+        query_string += self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="credit-risk",
+            uri="sovereign/credit-ratings",
+            querystring=query_string,
+        )
+
+    def get_sovereign_cds_spreads(
+        self,
+        api_token: str,
+        country: str = None,
+        as_of: str = None,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/credit-risk/sovereign/cds-spreads
+
+        Fields: country_iso3, country_name, as_of_date, moodys_rating,
+        cds_spread (nullable), cds_spread_net_of_switzerland (nullable), source.
+        """
+        query_string = ""
+        query_string += self._filter("country", country)
+        query_string += self._filter("as_of", as_of)
+        query_string += self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="credit-risk",
+            uri="sovereign/cds-spreads",
+            querystring=query_string,
+        )
+
+    def get_sovereign_default_spreads(
+        self,
+        api_token: str,
+        rating: str = None,
+        as_of: str = None,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/credit-risk/sovereign/default-spreads
+
+        Fields: rating, as_of_date, default_spread, source.
+        """
+        query_string = ""
+        query_string += self._filter("rating", rating)
+        query_string += self._filter("as_of", as_of)
+        query_string += self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="credit-risk",
+            uri="sovereign/default-spreads",
+            querystring=query_string,
+        )
+
+    def get_corporate_cmdi(
+        self,
+        api_token: str,
+        from_date: str = None,
+        to_date: str = None,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/credit-risk/corporate/cmdi
+
+        Filters: filter[from], filter[to].
+        Fields: as_of_date, market_cmdi, ig_cmdi, hy_cmdi, source.
+        """
+        query_string = ""
+        query_string += self._filter("from", from_date)
+        query_string += self._filter("to", to_date)
+        query_string += self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="credit-risk",
+            uri="corporate/cmdi",
+            querystring=query_string,
+        )
+
+    def get_corporate_hqm_yields(
+        self,
+        api_token: str,
+        tenor: str = None,
+        type: str = None,
+        from_date: str = None,
+        to_date: str = None,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/credit-risk/corporate/hqm-yields
+
+        Filters: filter[tenor], filter[type] (par|spot), filter[from], filter[to].
+        Fields: series_id, tenor_years, yield_type, as_of_date, yield_value, source.
+        """
+        if type is not None and str(type).lower() not in ("par", "spot"):
+            raise ValueError("type must be 'par' or 'spot'.")
+
+        query_string = ""
+        query_string += self._filter("tenor", tenor)
+        if type is not None:
+            query_string += self._filter("type", str(type).lower())
+        query_string += self._filter("from", from_date)
+        query_string += self._filter("to", to_date)
+        query_string += self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="credit-risk",
+            uri="corporate/hqm-yields",
+            querystring=query_string,
+        )
+
+    def get_cds_market_aggregates(
+        self,
+        api_token: str,
+        metric: str = None,
+        dimension: str = None,
+        from_date: str = None,
+        to_date: str = None,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/credit-risk/cds-market/aggregates
+
+        Filters: filter[metric] (gross_notional), filter[dimension] (grade|cleared_status),
+        filter[from], filter[to].
+        Fields: as_of_date, release_date, metric, breakdown_dimension,
+        breakdown_value, region, usd_notional_mn, source.
+        """
+        query_string = ""
+        query_string += self._filter("metric", metric)
+        query_string += self._filter("dimension", dimension)
+        query_string += self._filter("from", from_date)
+        query_string += self._filter("to", to_date)
+        query_string += self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="credit-risk",
+            uri="cds-market/aggregates",
+            querystring=query_string,
+        )

--- a/eodhd/APIs/CreditSovereignRiskAPI.py
+++ b/eodhd/APIs/CreditSovereignRiskAPI.py
@@ -191,15 +191,21 @@ class CreditSovereignRiskAPI(BaseAPI):
         GET /api/credit-risk/corporate/hqm-yields
 
         Filters: filter[tenor], filter[type] (par|spot), filter[from], filter[to].
+        Both filter[tenor] and filter[type] accept a comma-separated list
+        (e.g. type="spot,par"), matching the server's CsvIn validation.
         Fields: series_id, tenor_years, yield_type, as_of_date, yield_value, source.
         """
-        if type is not None and str(type).lower() not in ("par", "spot"):
-            raise ValueError("type must be 'par' or 'spot'.")
+        type_value = None
+        if type is not None:
+            parts = [p.strip().lower() for p in str(type).split(",") if p.strip()]
+            if not parts or any(p not in ("par", "spot") for p in parts):
+                raise ValueError("type must be 'par', 'spot', or a comma-separated combination (e.g. 'spot,par').")
+            type_value = ",".join(parts)
 
         query_string = ""
         query_string += self._filter("tenor", tenor)
-        if type is not None:
-            query_string += self._filter("type", str(type).lower())
+        if type_value is not None:
+            query_string += self._filter("type", type_value)
         query_string += self._filter("from", from_date)
         query_string += self._filter("to", to_date)
         query_string += self._pagination(page_offset, page_limit)
@@ -216,6 +222,8 @@ class CreditSovereignRiskAPI(BaseAPI):
         api_token: str,
         metric: str = None,
         dimension: str = None,
+        value: str = None,
+        region: str = None,
         from_date: str = None,
         to_date: str = None,
         page_offset: int = None,
@@ -225,13 +233,15 @@ class CreditSovereignRiskAPI(BaseAPI):
         GET /api/credit-risk/cds-market/aggregates
 
         Filters: filter[metric] (gross_notional), filter[dimension] (grade|cleared_status),
-        filter[from], filter[to].
+        filter[value] (a specific breakdown value), filter[region], filter[from], filter[to].
         Fields: as_of_date, release_date, metric, breakdown_dimension,
         breakdown_value, region, usd_notional_mn, source.
         """
         query_string = ""
         query_string += self._filter("metric", metric)
         query_string += self._filter("dimension", dimension)
+        query_string += self._filter("value", value)
+        query_string += self._filter("region", region)
         query_string += self._filter("from", from_date)
         query_string += self._filter("to", to_date)
         query_string += self._pagination(page_offset, page_limit)

--- a/eodhd/APIs/CreditSovereignRiskAPI.py
+++ b/eodhd/APIs/CreditSovereignRiskAPI.py
@@ -1,7 +1,5 @@
 # APIs/CreditSovereignRiskAPI.py
 
-from urllib.parse import quote
-
 from .BaseAPI import BaseAPI
 
 
@@ -21,29 +19,10 @@ class CreditSovereignRiskAPI(BaseAPI):
     - All endpoints return a JSON envelope { data, meta, links }.
     - Filtering uses filter[...] deep-object params.
     - Pagination uses page[offset] and page[limit].
+    - Value-level validation is limited to the small closed enums the server
+      guarantees (e.g. HQM yield type par/spot); other filter values (metric,
+      dimension, tenor grid, dates, lengths) are validated server-side.
     """
-
-    @staticmethod
-    def _filter(name: str, value) -> str:
-        """Build a URL-encoded &filter[name]=value fragment (empty if value is None)."""
-        if value is None:
-            return ""
-        return f"&filter[{name}]={quote(str(value), safe='')}"
-
-    @staticmethod
-    def _pagination(page_offset: int = None, page_limit: int = None) -> str:
-        query_string = ""
-        if page_offset is not None:
-            page_offset = int(page_offset)
-            if page_offset < 0:
-                raise ValueError("page_offset must be >= 0.")
-            query_string += f"&page[offset]={page_offset}"
-        if page_limit is not None:
-            page_limit = int(page_limit)
-            if page_limit < 1:
-                raise ValueError("page_limit must be >= 1.")
-            query_string += f"&page[limit]={page_limit}"
-        return query_string
 
     def get_sovereign_risk_premium(
         self,
@@ -181,7 +160,7 @@ class CreditSovereignRiskAPI(BaseAPI):
         self,
         api_token: str,
         tenor: str = None,
-        type: str = None,
+        yield_type: str = None,
         from_date: str = None,
         to_date: str = None,
         page_offset: int = None,
@@ -192,20 +171,22 @@ class CreditSovereignRiskAPI(BaseAPI):
 
         Filters: filter[tenor], filter[type] (par|spot), filter[from], filter[to].
         Both filter[tenor] and filter[type] accept a comma-separated list
-        (e.g. type="spot,par"), matching the server's CsvIn validation.
+        (e.g. yield_type="spot,par"), matching the server's CsvIn validation.
+        `yield_type` is serialised to filter[type]; the tenor grid is validated
+        server-side. A blank/empty value is treated as "no filter", not an error.
         Fields: series_id, tenor_years, yield_type, as_of_date, yield_value, source.
         """
-        type_value = None
-        if type is not None:
-            parts = [p.strip().lower() for p in str(type).split(",") if p.strip()]
-            if not parts or any(p not in ("par", "spot") for p in parts):
-                raise ValueError("type must be 'par', 'spot', or a comma-separated combination (e.g. 'spot,par').")
-            type_value = ",".join(parts)
+        yield_type_value = None
+        if yield_type is not None:
+            parts = [p.strip().lower() for p in str(yield_type).split(",") if p.strip()]
+            if parts and any(p not in ("par", "spot") for p in parts):
+                raise ValueError("yield_type must be 'par', 'spot', or a comma-separated combination (e.g. 'spot,par').")
+            if parts:
+                yield_type_value = ",".join(parts)
 
         query_string = ""
         query_string += self._filter("tenor", tenor)
-        if type_value is not None:
-            query_string += self._filter("type", type_value)
+        query_string += self._filter("type", yield_type_value)
         query_string += self._filter("from", from_date)
         query_string += self._filter("to", to_date)
         query_string += self._pagination(page_offset, page_limit)

--- a/eodhd/APIs/InterestRatesAPI.py
+++ b/eodhd/APIs/InterestRatesAPI.py
@@ -1,7 +1,5 @@
 # APIs/InterestRatesAPI.py
 
-from urllib.parse import quote
-
 from .BaseAPI import BaseAPI
 
 
@@ -19,28 +17,6 @@ class InterestRatesAPI(BaseAPI):
     - rates/* endpoints paginate with page[offset]/page[limit].
     - spreads/funding-stress does NOT support pagination.
     """
-
-    @staticmethod
-    def _filter(name: str, value) -> str:
-        """Build a URL-encoded &filter[name]=value fragment (empty if value is None)."""
-        if value is None:
-            return ""
-        return f"&filter[{name}]={quote(str(value), safe='')}"
-
-    @staticmethod
-    def _pagination(page_offset: int = None, page_limit: int = None) -> str:
-        query_string = ""
-        if page_offset is not None:
-            page_offset = int(page_offset)
-            if page_offset < 0:
-                raise ValueError("page_offset must be >= 0.")
-            query_string += f"&page[offset]={page_offset}"
-        if page_limit is not None:
-            page_limit = int(page_limit)
-            if page_limit < 1:
-                raise ValueError("page_limit must be >= 1.")
-            query_string += f"&page[limit]={page_limit}"
-        return query_string
 
     def get_reference_rates(
         self,

--- a/eodhd/APIs/InterestRatesAPI.py
+++ b/eodhd/APIs/InterestRatesAPI.py
@@ -55,12 +55,12 @@ class InterestRatesAPI(BaseAPI):
         """
         GET /api/rates/reference-rates
 
-        Filters: filter[code], filter[currency] (USD|GBP|EUR), filter[from], filter[to].
+        Filters: filter[code], filter[currency], filter[from], filter[to].
+        Currently populated currencies are USD (SOFR), GBP (SONIA) and EUR (ESTR);
+        the value is uppercased but not restricted client-side, since the server
+        does not enforce a fixed currency set.
         Fields: date, code, currency, rate_type, rate, source, source_series_id.
         """
-        if currency is not None and str(currency).upper() not in ("USD", "GBP", "EUR"):
-            raise ValueError("currency must be one of 'USD', 'GBP', 'EUR'.")
-
         query_string = ""
         query_string += self._filter("code", code)
         if currency is not None:

--- a/eodhd/APIs/InterestRatesAPI.py
+++ b/eodhd/APIs/InterestRatesAPI.py
@@ -1,0 +1,134 @@
+# APIs/InterestRatesAPI.py
+
+from urllib.parse import quote
+
+from .BaseAPI import BaseAPI
+
+
+class InterestRatesAPI(BaseAPI):
+    """
+    Wrapper for Interest Rates & Spreads endpoints:
+
+        GET /api/rates/reference-rates
+        GET /api/rates/policy-rates
+        GET /api/spreads/funding-stress
+
+    Notes:
+    - All endpoints return a JSON envelope { data, meta, links }.
+    - Filtering uses filter[...] deep-object params.
+    - rates/* endpoints paginate with page[offset]/page[limit].
+    - spreads/funding-stress does NOT support pagination.
+    """
+
+    @staticmethod
+    def _filter(name: str, value) -> str:
+        """Build a URL-encoded &filter[name]=value fragment (empty if value is None)."""
+        if value is None:
+            return ""
+        return f"&filter[{name}]={quote(str(value), safe='')}"
+
+    @staticmethod
+    def _pagination(page_offset: int = None, page_limit: int = None) -> str:
+        query_string = ""
+        if page_offset is not None:
+            page_offset = int(page_offset)
+            if page_offset < 0:
+                raise ValueError("page_offset must be >= 0.")
+            query_string += f"&page[offset]={page_offset}"
+        if page_limit is not None:
+            page_limit = int(page_limit)
+            if page_limit < 1:
+                raise ValueError("page_limit must be >= 1.")
+            query_string += f"&page[limit]={page_limit}"
+        return query_string
+
+    def get_reference_rates(
+        self,
+        api_token: str,
+        code: str = None,
+        currency: str = None,
+        from_date: str = None,
+        to_date: str = None,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/rates/reference-rates
+
+        Filters: filter[code], filter[currency] (USD|GBP|EUR), filter[from], filter[to].
+        Fields: date, code, currency, rate_type, rate, source, source_series_id.
+        """
+        if currency is not None and str(currency).upper() not in ("USD", "GBP", "EUR"):
+            raise ValueError("currency must be one of 'USD', 'GBP', 'EUR'.")
+
+        query_string = ""
+        query_string += self._filter("code", code)
+        if currency is not None:
+            query_string += self._filter("currency", str(currency).upper())
+        query_string += self._filter("from", from_date)
+        query_string += self._filter("to", to_date)
+        query_string += self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="rates",
+            uri="reference-rates",
+            querystring=query_string,
+        )
+
+    def get_policy_rates(
+        self,
+        api_token: str,
+        code: str = None,
+        country: str = None,
+        central_bank: str = None,
+        from_date: str = None,
+        to_date: str = None,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/rates/policy-rates
+
+        Filters: filter[code], filter[country], filter[central_bank], filter[from], filter[to].
+        Fields: date, code, country, central_bank, rate, source, source_series_id.
+        """
+        query_string = ""
+        query_string += self._filter("code", code)
+        query_string += self._filter("country", country)
+        query_string += self._filter("central_bank", central_bank)
+        query_string += self._filter("from", from_date)
+        query_string += self._filter("to", to_date)
+        query_string += self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="rates",
+            uri="policy-rates",
+            querystring=query_string,
+        )
+
+    def get_funding_stress(
+        self,
+        api_token: str,
+        code: str = None,
+        from_date: str = None,
+        to_date: str = None,
+    ):
+        """
+        GET /api/spreads/funding-stress
+
+        Filters: filter[code], filter[from], filter[to]. NO pagination.
+        Fields: date, code, value_bps, formula, leg_a, leg_b, leg_a_rate, leg_b_rate.
+        """
+        query_string = ""
+        query_string += self._filter("code", code)
+        query_string += self._filter("from", from_date)
+        query_string += self._filter("to", to_date)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="spreads",
+            uri="funding-stress",
+            querystring=query_string,
+        )

--- a/eodhd/APIs/SanctionsAPI.py
+++ b/eodhd/APIs/SanctionsAPI.py
@@ -174,44 +174,30 @@ class SanctionsAPI(BaseAPI):
             querystring=query_string,
         )
 
-    def get_programs(
-        self,
-        api_token: str,
-        page_offset: int = None,
-        page_limit: int = None,
-    ):
+    def get_programs(self, api_token: str):
         """
         GET /api/sanctions/programs
 
-        No filter params (pagination only).
+        No params and no pagination (the server ignores any query params here).
         Fields: program, count.
         """
-        query_string = self._pagination(page_offset, page_limit)
-
         return self._rest_get_method(
             api_key=api_token,
             endpoint="sanctions",
             uri="programs",
-            querystring=query_string,
+            querystring="",
         )
 
-    def get_sources(
-        self,
-        api_token: str,
-        page_offset: int = None,
-        page_limit: int = None,
-    ):
+    def get_sources(self, api_token: str):
         """
         GET /api/sanctions/sources
 
-        No filter params (pagination only).
+        No params and no pagination (the server ignores any query params here).
         Fields: name.
         """
-        query_string = self._pagination(page_offset, page_limit)
-
         return self._rest_get_method(
             api_key=api_token,
             endpoint="sanctions",
             uri="sources",
-            querystring=query_string,
+            querystring="",
         )

--- a/eodhd/APIs/SanctionsAPI.py
+++ b/eodhd/APIs/SanctionsAPI.py
@@ -1,7 +1,5 @@
 # APIs/SanctionsAPI.py
 
-from urllib.parse import quote
-
 from .BaseAPI import BaseAPI
 
 
@@ -19,55 +17,29 @@ class SanctionsAPI(BaseAPI):
     - Filtering uses BARE query params (e.g. program=, q=, type=), NOT filter[...].
       (This differs from other EODHD endpoints; verified against prometheus-web
       request classes + live production.)
-    - Pagination uses page[offset] and page[limit].
+    - Pagination (page[offset]/page[limit]) applies to entities and vessels only;
+      programs and sources take no params and are not paginated.
     """
 
     _SOURCE_VALUES = ("ofac",)
     _ENTITY_TYPE_VALUES = ("individual", "entity", "vessel", "aircraft")
 
     @staticmethod
-    def _param(name: str, value) -> str:
-        """Build a URL-encoded &name=value fragment.
-
-        Returns "" for None or blank/whitespace-only values (so an empty string
-        is treated as "omit the param", not "send &name="). Values are
-        URL-encoded; the key is a bare query param (not filter[...])."""
-        if value is None:
-            return ""
-        text = str(value).strip()
-        if text == "":
-            return ""
-        return f"&{name}={quote(text, safe='')}"
-
-    @staticmethod
     def _normalize_active(active):
         """Normalise the `active` filter to the API's "true"/"false" scalar.
 
-        Accepts Python bools, or the strings "true"/"false" (any case). Anything
-        else raises ValueError. Returns None if `active` is None."""
+        Accepts Python bools, or the strings "true"/"false" (any case). A blank
+        value is treated as absent (returns None); anything else raises ValueError."""
         if active is None:
             return None
         if isinstance(active, bool):
             return "true" if active else "false"
         text = str(active).strip().lower()
+        if text == "":
+            return None
         if text not in ("true", "false"):
             raise ValueError("active must be a bool or one of 'true'/'false'.")
         return text
-
-    @staticmethod
-    def _pagination(page_offset: int = None, page_limit: int = None) -> str:
-        query_string = ""
-        if page_offset is not None:
-            page_offset = int(page_offset)
-            if page_offset < 0:
-                raise ValueError("page_offset must be >= 0.")
-            query_string += f"&page[offset]={page_offset}"
-        if page_limit is not None:
-            page_limit = int(page_limit)
-            if page_limit < 1:
-                raise ValueError("page_limit must be >= 1.")
-            query_string += f"&page[limit]={page_limit}"
-        return query_string
 
     def get_entities(
         self,
@@ -97,6 +69,9 @@ class SanctionsAPI(BaseAPI):
         Fields: source, source_uid, entity_type, name, programs[], country,
         remarks, listed_date, is_active, aliases[], identifiers[].
         """
+        q = self._blank_to_none(q)
+        source = self._blank_to_none(source)
+        entity_type = self._blank_to_none(entity_type)
         if q is not None and len(str(q).strip()) < 2:
             raise ValueError("q (search) must be at least 2 characters.")
         if source is not None and str(source).strip().lower() not in self._SOURCE_VALUES:
@@ -152,6 +127,8 @@ class SanctionsAPI(BaseAPI):
         imo_number, mmsi, entity_source_uid, entity_name, source, programs[],
         country, is_active.
         """
+        q = self._blank_to_none(q)
+        source = self._blank_to_none(source)
         if q is not None and len(str(q).strip()) < 2:
             raise ValueError("q (search) must be at least 2 characters.")
         if source is not None and str(source).strip().lower() not in self._SOURCE_VALUES:

--- a/eodhd/APIs/SanctionsAPI.py
+++ b/eodhd/APIs/SanctionsAPI.py
@@ -1,0 +1,217 @@
+# APIs/SanctionsAPI.py
+
+from urllib.parse import quote
+
+from .BaseAPI import BaseAPI
+
+
+class SanctionsAPI(BaseAPI):
+    """
+    Wrapper for Sanctions endpoints:
+
+        GET /api/sanctions/entities
+        GET /api/sanctions/vessels
+        GET /api/sanctions/programs
+        GET /api/sanctions/sources
+
+    Notes:
+    - All endpoints return a JSON envelope { data, meta, links }.
+    - Filtering uses BARE query params (e.g. program=, q=, type=), NOT filter[...].
+      (This differs from other EODHD endpoints; verified against prometheus-web
+      request classes + live production.)
+    - Pagination uses page[offset] and page[limit].
+    """
+
+    _SOURCE_VALUES = ("ofac",)
+    _ENTITY_TYPE_VALUES = ("individual", "entity", "vessel", "aircraft")
+
+    @staticmethod
+    def _param(name: str, value) -> str:
+        """Build a URL-encoded &name=value fragment.
+
+        Returns "" for None or blank/whitespace-only values (so an empty string
+        is treated as "omit the param", not "send &name="). Values are
+        URL-encoded; the key is a bare query param (not filter[...])."""
+        if value is None:
+            return ""
+        text = str(value).strip()
+        if text == "":
+            return ""
+        return f"&{name}={quote(text, safe='')}"
+
+    @staticmethod
+    def _normalize_active(active):
+        """Normalise the `active` filter to the API's "true"/"false" scalar.
+
+        Accepts Python bools, or the strings "true"/"false" (any case). Anything
+        else raises ValueError. Returns None if `active` is None."""
+        if active is None:
+            return None
+        if isinstance(active, bool):
+            return "true" if active else "false"
+        text = str(active).strip().lower()
+        if text not in ("true", "false"):
+            raise ValueError("active must be a bool or one of 'true'/'false'.")
+        return text
+
+    @staticmethod
+    def _pagination(page_offset: int = None, page_limit: int = None) -> str:
+        query_string = ""
+        if page_offset is not None:
+            page_offset = int(page_offset)
+            if page_offset < 0:
+                raise ValueError("page_offset must be >= 0.")
+            query_string += f"&page[offset]={page_offset}"
+        if page_limit is not None:
+            page_limit = int(page_limit)
+            if page_limit < 1:
+                raise ValueError("page_limit must be >= 1.")
+            query_string += f"&page[limit]={page_limit}"
+        return query_string
+
+    def get_entities(
+        self,
+        api_token: str,
+        q: str = None,
+        program: str = None,
+        country: str = None,
+        source: str = None,
+        entity_type: str = None,
+        active: bool = None,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/sanctions/entities
+
+        Query params (bare, not filter[...]):
+            q           - free-text search (min 2 chars)
+            program     - sanctions program
+            country     - country
+            source      - data source; currently only "ofac"
+            type        - entity type: "individual" | "entity" | "vessel" | "aircraft"
+                          (Python arg name: entity_type)
+            active      - "true" | "false" (Python bool accepted)
+            page[offset], page[limit] - pagination
+
+        Fields: source, source_uid, entity_type, name, programs[], country,
+        remarks, listed_date, is_active, aliases[], identifiers[].
+        """
+        if q is not None and len(str(q).strip()) < 2:
+            raise ValueError("q (search) must be at least 2 characters.")
+        if source is not None and str(source).strip().lower() not in self._SOURCE_VALUES:
+            raise ValueError(f"source must be one of {self._SOURCE_VALUES}.")
+        if entity_type is not None and str(entity_type).strip().lower() not in self._ENTITY_TYPE_VALUES:
+            raise ValueError(f"type must be one of {self._ENTITY_TYPE_VALUES}.")
+        active = self._normalize_active(active)
+
+        query_string = ""
+        query_string += self._param("q", q)
+        query_string += self._param("program", program)
+        query_string += self._param("country", country)
+        if source is not None:
+            query_string += self._param("source", str(source).strip().lower())
+        if entity_type is not None:
+            query_string += self._param("type", str(entity_type).strip().lower())
+        if active is not None:
+            query_string += self._param("active", active)
+        query_string += self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="sanctions",
+            uri="entities",
+            querystring=query_string,
+        )
+
+    def get_vessels(
+        self,
+        api_token: str,
+        q: str = None,
+        imo: str = None,
+        flag: str = None,
+        vessel_type: str = None,
+        program: str = None,
+        source: str = None,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/sanctions/vessels
+
+        Query params (bare, not filter[...]):
+            q           - free-text search (min 2 chars)
+            imo         - IMO number
+            flag        - flag
+            vessel_type - vessel type
+            program     - sanctions program
+            source      - data source; currently only "ofac"
+            page[offset], page[limit] - pagination
+
+        Fields: call_sign, vessel_type, flag, tonnage, gross_tonnage, owner,
+        imo_number, mmsi, entity_source_uid, entity_name, source, programs[],
+        country, is_active.
+        """
+        if q is not None and len(str(q).strip()) < 2:
+            raise ValueError("q (search) must be at least 2 characters.")
+        if source is not None and str(source).strip().lower() not in self._SOURCE_VALUES:
+            raise ValueError(f"source must be one of {self._SOURCE_VALUES}.")
+
+        query_string = ""
+        query_string += self._param("q", q)
+        query_string += self._param("imo", imo)
+        query_string += self._param("flag", flag)
+        query_string += self._param("vessel_type", vessel_type)
+        query_string += self._param("program", program)
+        if source is not None:
+            query_string += self._param("source", str(source).strip().lower())
+        query_string += self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="sanctions",
+            uri="vessels",
+            querystring=query_string,
+        )
+
+    def get_programs(
+        self,
+        api_token: str,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/sanctions/programs
+
+        No filter params (pagination only).
+        Fields: program, count.
+        """
+        query_string = self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="sanctions",
+            uri="programs",
+            querystring=query_string,
+        )
+
+    def get_sources(
+        self,
+        api_token: str,
+        page_offset: int = None,
+        page_limit: int = None,
+    ):
+        """
+        GET /api/sanctions/sources
+
+        No filter params (pagination only).
+        Fields: name.
+        """
+        query_string = self._pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="sanctions",
+            uri="sources",
+            querystring=query_string,
+        )

--- a/eodhd/APIs/__init__.py
+++ b/eodhd/APIs/__init__.py
@@ -34,6 +34,9 @@ from .UserAPI import UserAPI
 from .BulkFundamentalsAPI import BulkFundamentalsAPI
 from .TreasuryAPI import TreasuryAPI
 from .ExchangeDetailsV2API import ExchangeDetailsV2API
+from .CreditSovereignRiskAPI import CreditSovereignRiskAPI
+from .SanctionsAPI import SanctionsAPI
+from .InterestRatesAPI import InterestRatesAPI
 
 #Marketplace endpoints
 from .MPIndexComponentsAPI import MPIndexComponentsAPI

--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -1741,23 +1741,23 @@ class APIClient:
             page_offset=page_offset, page_limit=page_limit,
         )
 
-    def get_corporate_hqm_yields(self, tenor=None, type=None, from_date=None,
+    def get_corporate_hqm_yields(self, tenor=None, yield_type=None, from_date=None,
                                  to_date=None, page_offset=None, page_limit=None):
         """
         Credit & Sovereign Risk: corporate HQM yields
         Endpoint: GET /api/credit-risk/corporate/hqm-yields
 
         Args:
-            tenor     [OPTIONAL] - filter[tenor]
-            type      [OPTIONAL] - filter[type], "par" or "spot"
-            from_date [OPTIONAL] - filter[from], YYYY-MM-DD
-            to_date   [OPTIONAL] - filter[to], YYYY-MM-DD
+            tenor      [OPTIONAL] - filter[tenor] (single value or CSV)
+            yield_type [OPTIONAL] - filter[type], "par", "spot" or CSV "spot,par"
+            from_date  [OPTIONAL] - filter[from], YYYY-MM-DD
+            to_date    [OPTIONAL] - filter[to], YYYY-MM-DD
             page_offset / page_limit [OPTIONAL] - pagination
         Returns: dict envelope { data, meta, links }
         """
         api_call = CreditSovereignRiskAPI(session=self._session, timeout=self._timeout)
         return api_call.get_corporate_hqm_yields(
-            api_token=self._api_key, tenor=tenor, type=type, from_date=from_date,
+            api_token=self._api_key, tenor=tenor, yield_type=yield_type, from_date=from_date,
             to_date=to_date, page_offset=page_offset, page_limit=page_limit,
         )
 
@@ -1873,7 +1873,8 @@ class APIClient:
 
         Args:
             code      [OPTIONAL] - filter[code]
-            currency  [OPTIONAL] - filter[currency], "USD", "GBP" or "EUR"
+            currency  [OPTIONAL] - filter[currency]; currently populated: USD (SOFR),
+                        GBP (SONIA), EUR (ESTR). Uppercased but not restricted client-side.
             from_date [OPTIONAL] - filter[from], YYYY-MM-DD
             to_date   [OPTIONAL] - filter[to], YYYY-MM-DD
             page_offset / page_limit [OPTIONAL] - pagination

--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -51,6 +51,9 @@ from eodhd.APIs import UserAPI
 from eodhd.APIs import BulkFundamentalsAPI
 from eodhd.APIs import TreasuryAPI
 from eodhd.APIs import ExchangeDetailsV2API
+from eodhd.APIs import CreditSovereignRiskAPI
+from eodhd.APIs import SanctionsAPI
+from eodhd.APIs import InterestRatesAPI
 
 #Marketplace endpoints
 from eodhd.APIs import MPIndexComponentsAPI
@@ -1643,6 +1646,285 @@ class APIClient:
         """
         api_call = MPUnicornbayExtrasAPI(session=self._session, timeout=self._timeout)
         return api_call.get_logo(api_token=self._api_key, symbol=symbol)
+
+    # ------------------------------------------------------------------
+    # Credit & Sovereign Risk API (/api/credit-risk)
+    # ------------------------------------------------------------------
+    def get_sovereign_risk_premium(self, country=None, region=None, as_of=None,
+                                   page_offset=None, page_limit=None):
+        """
+        Credit & Sovereign Risk: sovereign risk premium
+        Endpoint: GET /api/credit-risk/sovereign/risk-premium
+
+        Args:
+            country [OPTIONAL] - filter[country], e.g. "USA" or "US"
+            region  [OPTIONAL] - filter[region]
+            as_of   [OPTIONAL] - filter[as_of], YYYY-MM-DD
+            page_offset / page_limit [OPTIONAL] - pagination
+        Returns: dict envelope { data, meta, links }
+        """
+        api_call = CreditSovereignRiskAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_sovereign_risk_premium(
+            api_token=self._api_key, country=country, region=region, as_of=as_of,
+            page_offset=page_offset, page_limit=page_limit,
+        )
+
+    def get_sovereign_credit_ratings(self, country=None, as_of=None,
+                                     page_offset=None, page_limit=None):
+        """
+        Credit & Sovereign Risk: sovereign credit ratings
+        Endpoint: GET /api/credit-risk/sovereign/credit-ratings
+
+        Args:
+            country [OPTIONAL] - filter[country]
+            as_of   [OPTIONAL] - filter[as_of], YYYY-MM-DD
+            page_offset / page_limit [OPTIONAL] - pagination
+        Returns: dict envelope { data, meta, links }
+        """
+        api_call = CreditSovereignRiskAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_sovereign_credit_ratings(
+            api_token=self._api_key, country=country, as_of=as_of,
+            page_offset=page_offset, page_limit=page_limit,
+        )
+
+    def get_sovereign_cds_spreads(self, country=None, as_of=None,
+                                  page_offset=None, page_limit=None):
+        """
+        Credit & Sovereign Risk: sovereign CDS spreads
+        Endpoint: GET /api/credit-risk/sovereign/cds-spreads
+
+        Args:
+            country [OPTIONAL] - filter[country]
+            as_of   [OPTIONAL] - filter[as_of], YYYY-MM-DD
+            page_offset / page_limit [OPTIONAL] - pagination
+        Returns: dict envelope { data, meta, links }
+        """
+        api_call = CreditSovereignRiskAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_sovereign_cds_spreads(
+            api_token=self._api_key, country=country, as_of=as_of,
+            page_offset=page_offset, page_limit=page_limit,
+        )
+
+    def get_sovereign_default_spreads(self, rating=None, as_of=None,
+                                      page_offset=None, page_limit=None):
+        """
+        Credit & Sovereign Risk: sovereign default spreads
+        Endpoint: GET /api/credit-risk/sovereign/default-spreads
+
+        Args:
+            rating [OPTIONAL] - filter[rating]
+            as_of  [OPTIONAL] - filter[as_of], YYYY-MM-DD
+            page_offset / page_limit [OPTIONAL] - pagination
+        Returns: dict envelope { data, meta, links }
+        """
+        api_call = CreditSovereignRiskAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_sovereign_default_spreads(
+            api_token=self._api_key, rating=rating, as_of=as_of,
+            page_offset=page_offset, page_limit=page_limit,
+        )
+
+    def get_corporate_cmdi(self, from_date=None, to_date=None,
+                           page_offset=None, page_limit=None):
+        """
+        Credit & Sovereign Risk: corporate CMDI (credit market distress index)
+        Endpoint: GET /api/credit-risk/corporate/cmdi
+
+        Args:
+            from_date [OPTIONAL] - filter[from], YYYY-MM-DD
+            to_date   [OPTIONAL] - filter[to], YYYY-MM-DD
+            page_offset / page_limit [OPTIONAL] - pagination
+        Returns: dict envelope { data, meta, links }
+        """
+        api_call = CreditSovereignRiskAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_corporate_cmdi(
+            api_token=self._api_key, from_date=from_date, to_date=to_date,
+            page_offset=page_offset, page_limit=page_limit,
+        )
+
+    def get_corporate_hqm_yields(self, tenor=None, type=None, from_date=None,
+                                 to_date=None, page_offset=None, page_limit=None):
+        """
+        Credit & Sovereign Risk: corporate HQM yields
+        Endpoint: GET /api/credit-risk/corporate/hqm-yields
+
+        Args:
+            tenor     [OPTIONAL] - filter[tenor]
+            type      [OPTIONAL] - filter[type], "par" or "spot"
+            from_date [OPTIONAL] - filter[from], YYYY-MM-DD
+            to_date   [OPTIONAL] - filter[to], YYYY-MM-DD
+            page_offset / page_limit [OPTIONAL] - pagination
+        Returns: dict envelope { data, meta, links }
+        """
+        api_call = CreditSovereignRiskAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_corporate_hqm_yields(
+            api_token=self._api_key, tenor=tenor, type=type, from_date=from_date,
+            to_date=to_date, page_offset=page_offset, page_limit=page_limit,
+        )
+
+    def get_cds_market_aggregates(self, metric=None, dimension=None, from_date=None,
+                                  to_date=None, page_offset=None, page_limit=None):
+        """
+        Credit & Sovereign Risk: CDS market aggregates
+        Endpoint: GET /api/credit-risk/cds-market/aggregates
+
+        Args:
+            metric    [OPTIONAL] - filter[metric], e.g. "gross_notional"
+            dimension [OPTIONAL] - filter[dimension], "grade" or "cleared_status"
+            from_date [OPTIONAL] - filter[from], YYYY-MM-DD
+            to_date   [OPTIONAL] - filter[to], YYYY-MM-DD
+            page_offset / page_limit [OPTIONAL] - pagination
+        Returns: dict envelope { data, meta, links }
+        """
+        api_call = CreditSovereignRiskAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_cds_market_aggregates(
+            api_token=self._api_key, metric=metric, dimension=dimension,
+            from_date=from_date, to_date=to_date,
+            page_offset=page_offset, page_limit=page_limit,
+        )
+
+    # ------------------------------------------------------------------
+    # Sanctions API (/api/sanctions)
+    # ------------------------------------------------------------------
+    def get_sanctions_entities(self, q=None, program=None, country=None, source=None,
+                               entity_type=None, active=None,
+                               page_offset=None, page_limit=None):
+        """
+        Sanctions: sanctioned entities
+        Endpoint: GET /api/sanctions/entities
+
+        Note: sanctions endpoints use bare query params, NOT filter[...].
+
+        Args:
+            q           [OPTIONAL] - free-text search (min 2 chars)
+            program     [OPTIONAL] - program
+            country     [OPTIONAL] - country
+            source      [OPTIONAL] - source (currently only "ofac")
+            entity_type [OPTIONAL] - type: "individual"|"entity"|"vessel"|"aircraft"
+            active      [OPTIONAL] - "true"/"false" (bool accepted)
+            page_offset / page_limit [OPTIONAL] - pagination
+        Returns: dict envelope { data, meta, links }
+        """
+        api_call = SanctionsAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_entities(
+            api_token=self._api_key, q=q, program=program, country=country,
+            source=source, entity_type=entity_type, active=active,
+            page_offset=page_offset, page_limit=page_limit,
+        )
+
+    def get_sanctions_vessels(self, q=None, imo=None, flag=None, vessel_type=None,
+                              program=None, source=None,
+                              page_offset=None, page_limit=None):
+        """
+        Sanctions: sanctioned vessels
+        Endpoint: GET /api/sanctions/vessels
+
+        Note: sanctions endpoints use bare query params, NOT filter[...].
+
+        Args:
+            q           [OPTIONAL] - free-text search (min 2 chars)
+            imo         [OPTIONAL] - IMO number
+            flag        [OPTIONAL] - flag
+            vessel_type [OPTIONAL] - vessel type
+            program     [OPTIONAL] - program
+            source      [OPTIONAL] - source (currently only "ofac")
+            page_offset / page_limit [OPTIONAL] - pagination
+        Returns: dict envelope { data, meta, links }
+        """
+        api_call = SanctionsAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_vessels(
+            api_token=self._api_key, q=q, imo=imo, flag=flag, vessel_type=vessel_type,
+            program=program, source=source,
+            page_offset=page_offset, page_limit=page_limit,
+        )
+
+    def get_sanctions_programs(self, page_offset=None, page_limit=None):
+        """
+        Sanctions: list of sanctions programs
+        Endpoint: GET /api/sanctions/programs
+
+        Returns: dict envelope { data, meta, links }; data items have program, count.
+        """
+        api_call = SanctionsAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_programs(
+            api_token=self._api_key, page_offset=page_offset, page_limit=page_limit,
+        )
+
+    def get_sanctions_sources(self, page_offset=None, page_limit=None):
+        """
+        Sanctions: list of sanctions sources
+        Endpoint: GET /api/sanctions/sources
+
+        Returns: dict envelope { data, meta, links }; data items have name.
+        """
+        api_call = SanctionsAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_sources(
+            api_token=self._api_key, page_offset=page_offset, page_limit=page_limit,
+        )
+
+    # ------------------------------------------------------------------
+    # Interest Rates & Spreads API (/api/rates, /api/spreads)
+    # ------------------------------------------------------------------
+    def get_reference_rates(self, code=None, currency=None, from_date=None, to_date=None,
+                            page_offset=None, page_limit=None):
+        """
+        Interest Rates: reference rates
+        Endpoint: GET /api/rates/reference-rates
+
+        Args:
+            code      [OPTIONAL] - filter[code]
+            currency  [OPTIONAL] - filter[currency], "USD", "GBP" or "EUR"
+            from_date [OPTIONAL] - filter[from], YYYY-MM-DD
+            to_date   [OPTIONAL] - filter[to], YYYY-MM-DD
+            page_offset / page_limit [OPTIONAL] - pagination
+        Returns: dict envelope { data, meta, links }
+        """
+        api_call = InterestRatesAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_reference_rates(
+            api_token=self._api_key, code=code, currency=currency,
+            from_date=from_date, to_date=to_date,
+            page_offset=page_offset, page_limit=page_limit,
+        )
+
+    def get_policy_rates(self, code=None, country=None, central_bank=None,
+                         from_date=None, to_date=None,
+                         page_offset=None, page_limit=None):
+        """
+        Interest Rates: central bank policy rates
+        Endpoint: GET /api/rates/policy-rates
+
+        Args:
+            code         [OPTIONAL] - filter[code]
+            country      [OPTIONAL] - filter[country]
+            central_bank [OPTIONAL] - filter[central_bank]
+            from_date    [OPTIONAL] - filter[from], YYYY-MM-DD
+            to_date      [OPTIONAL] - filter[to], YYYY-MM-DD
+            page_offset / page_limit [OPTIONAL] - pagination
+        Returns: dict envelope { data, meta, links }
+        """
+        api_call = InterestRatesAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_policy_rates(
+            api_token=self._api_key, code=code, country=country,
+            central_bank=central_bank, from_date=from_date, to_date=to_date,
+            page_offset=page_offset, page_limit=page_limit,
+        )
+
+    def get_funding_stress(self, code=None, from_date=None, to_date=None):
+        """
+        Spreads: funding stress spreads
+        Endpoint: GET /api/spreads/funding-stress
+
+        Note: this endpoint does NOT support pagination.
+
+        Args:
+            code      [OPTIONAL] - filter[code]
+            from_date [OPTIONAL] - filter[from], YYYY-MM-DD
+            to_date   [OPTIONAL] - filter[to], YYYY-MM-DD
+        Returns: dict envelope { data, meta, links }
+        """
+        api_call = InterestRatesAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_funding_stress(
+            api_token=self._api_key, code=code, from_date=from_date, to_date=to_date,
+        )
 
 
 class ScannerClient:

--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -1761,8 +1761,9 @@ class APIClient:
             to_date=to_date, page_offset=page_offset, page_limit=page_limit,
         )
 
-    def get_cds_market_aggregates(self, metric=None, dimension=None, from_date=None,
-                                  to_date=None, page_offset=None, page_limit=None):
+    def get_cds_market_aggregates(self, metric=None, dimension=None, value=None,
+                                  region=None, from_date=None, to_date=None,
+                                  page_offset=None, page_limit=None):
         """
         Credit & Sovereign Risk: CDS market aggregates
         Endpoint: GET /api/credit-risk/cds-market/aggregates
@@ -1770,6 +1771,8 @@ class APIClient:
         Args:
             metric    [OPTIONAL] - filter[metric], e.g. "gross_notional"
             dimension [OPTIONAL] - filter[dimension], "grade" or "cleared_status"
+            value     [OPTIONAL] - filter[value], a specific breakdown value
+            region    [OPTIONAL] - filter[region]
             from_date [OPTIONAL] - filter[from], YYYY-MM-DD
             to_date   [OPTIONAL] - filter[to], YYYY-MM-DD
             page_offset / page_limit [OPTIONAL] - pagination
@@ -1778,7 +1781,7 @@ class APIClient:
         api_call = CreditSovereignRiskAPI(session=self._session, timeout=self._timeout)
         return api_call.get_cds_market_aggregates(
             api_token=self._api_key, metric=metric, dimension=dimension,
-            from_date=from_date, to_date=to_date,
+            value=value, region=region, from_date=from_date, to_date=to_date,
             page_offset=page_offset, page_limit=page_limit,
         )
 
@@ -1837,29 +1840,27 @@ class APIClient:
             page_offset=page_offset, page_limit=page_limit,
         )
 
-    def get_sanctions_programs(self, page_offset=None, page_limit=None):
+    def get_sanctions_programs(self):
         """
         Sanctions: list of sanctions programs
         Endpoint: GET /api/sanctions/programs
 
+        Takes no params and is not paginated.
         Returns: dict envelope { data, meta, links }; data items have program, count.
         """
         api_call = SanctionsAPI(session=self._session, timeout=self._timeout)
-        return api_call.get_programs(
-            api_token=self._api_key, page_offset=page_offset, page_limit=page_limit,
-        )
+        return api_call.get_programs(api_token=self._api_key)
 
-    def get_sanctions_sources(self, page_offset=None, page_limit=None):
+    def get_sanctions_sources(self):
         """
         Sanctions: list of sanctions sources
         Endpoint: GET /api/sanctions/sources
 
+        Takes no params and is not paginated.
         Returns: dict envelope { data, meta, links }; data items have name.
         """
         api_call = SanctionsAPI(session=self._session, timeout=self._timeout)
-        return api_call.get_sources(
-            api_token=self._api_key, page_offset=page_offset, page_limit=page_limit,
-        )
+        return api_call.get_sources(api_token=self._api_key)
 
     # ------------------------------------------------------------------
     # Interest Rates & Spreads API (/api/rates, /api/spreads)

--- a/tests/test_apiclient_new_apis.py
+++ b/tests/test_apiclient_new_apis.py
@@ -1,0 +1,103 @@
+"""Facade-level tests for the Credit&Sovereign Risk / Sanctions / Interest Rates
+methods on APIClient.
+
+These complement the per-API-class tests: they exercise the public APIClient
+methods end-to-end (arg forwarding, param names, path, and the bare-vs-filter[...]
+convention) so a facade wiring regression (renamed/dropped kwarg, wrong path)
+is caught.
+"""
+
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from unittest.mock import MagicMock
+
+from eodhd import APIClient
+
+
+@pytest.fixture
+def client():
+    api = APIClient(api_key="test1234567890123456")
+    session = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"data": [], "meta": {}, "links": {}}
+    session.get.return_value = resp
+    api._session = session
+    return api
+
+
+def _split(session):
+    url = session.get.call_args[0][0]
+    parts = urlsplit(url)
+    return parts.path, parse_qs(parts.query, keep_blank_values=True)
+
+
+def test_facade_sovereign_risk_premium(client):
+    client.get_sovereign_risk_premium(country="USA", region="North America",
+                                      as_of="2024-01-01", page_offset=0, page_limit=50)
+    path, qs = _split(client._session)
+    assert path.endswith("/credit-risk/sovereign/risk-premium")
+    assert qs["filter[country]"] == ["USA"]
+    assert qs["filter[region]"] == ["North America"]
+    assert qs["page[offset]"] == ["0"]
+    assert qs["page[limit]"] == ["50"]
+
+
+def test_facade_cds_market_aggregates_value_region(client):
+    client.get_cds_market_aggregates(metric="gross_notional", dimension="grade",
+                                     value="Investment Grade", region="North America")
+    path, qs = _split(client._session)
+    assert path.endswith("/credit-risk/cds-market/aggregates")
+    assert qs["filter[value]"] == ["Investment Grade"]
+    assert qs["filter[region]"] == ["North America"]
+
+
+def test_facade_hqm_yields_yield_type(client):
+    client.get_corporate_hqm_yields(tenor="10", yield_type="spot,par")
+    path, qs = _split(client._session)
+    assert path.endswith("/credit-risk/corporate/hqm-yields")
+    assert qs["filter[tenor]"] == ["10"]
+    assert qs["filter[type]"] == ["spot,par"]
+
+
+def test_facade_sanctions_entities_bare_and_type_mapping(client):
+    client.get_sanctions_entities(program="OFAC-SDN", country="RU",
+                                  entity_type="individual", active=False)
+    path, qs = _split(client._session)
+    assert path.endswith("/sanctions/entities")
+    # bare params, entity_type -> type, active=False serialised to "false"
+    assert qs["program"] == ["OFAC-SDN"]
+    assert qs["type"] == ["individual"]
+    assert qs["active"] == ["false"]
+    assert not any(k.startswith("filter[") for k in qs)
+
+
+def test_facade_sanctions_vessels(client):
+    client.get_sanctions_vessels(imo="9074729", flag="RU", source="ofac")
+    path, qs = _split(client._session)
+    assert path.endswith("/sanctions/vessels")
+    assert qs["imo"] == ["9074729"]
+    assert qs["source"] == ["ofac"]
+
+
+def test_facade_sanctions_programs_sources_no_pagination(client):
+    for call in (client.get_sanctions_programs, client.get_sanctions_sources):
+        call()
+        _path, qs = _split(client._session)
+        assert not any(k.startswith("page[") for k in qs)
+
+
+def test_facade_reference_rates(client):
+    client.get_reference_rates(code="SOFR", currency="usd")
+    path, qs = _split(client._session)
+    assert path.endswith("/rates/reference-rates")
+    assert qs["filter[code]"] == ["SOFR"]
+    assert qs["filter[currency]"] == ["USD"]
+
+
+def test_facade_funding_stress_no_pagination(client):
+    client.get_funding_stress(code="SOFR_OIS")
+    path, qs = _split(client._session)
+    assert path.endswith("/spreads/funding-stress")
+    assert not any(k.startswith("page[") for k in qs)

--- a/tests/test_credit_sovereign_risk.py
+++ b/tests/test_credit_sovereign_risk.py
@@ -1,0 +1,140 @@
+"""Tests for CreditSovereignRiskAPI."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from eodhd.APIs.CreditSovereignRiskAPI import CreditSovereignRiskAPI
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock()
+
+
+def _make_api(session):
+    return CreditSovereignRiskAPI(session=session)
+
+
+def _mock_response(session, data=None):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = data if data is not None else {"data": [], "meta": {}, "links": {}}
+    session.get.return_value = resp
+
+
+def test_risk_premium_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_sovereign_risk_premium(api_token="test1234567890123456")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/credit-risk/sovereign/risk-premium" in call_url
+    assert "api_token=test1234567890123456" in call_url
+
+
+def test_risk_premium_filters(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_sovereign_risk_premium(
+        api_token="test1234567890123456", country="USA", region="North America",
+        as_of="2024-01-01", page_offset=0, page_limit=50,
+    )
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "filter[country]=USA" in call_url
+    # filter values are URL-encoded (spaces -> %20)
+    assert "filter[region]=North%20America" in call_url
+    assert "filter[as_of]=2024-01-01" in call_url
+    assert "page[offset]=0" in call_url
+    assert "page[limit]=50" in call_url
+
+
+def test_credit_ratings_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_sovereign_credit_ratings(api_token="test1234567890123456", country="DEU")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/credit-risk/sovereign/credit-ratings" in call_url
+    assert "filter[country]=DEU" in call_url
+
+
+def test_cds_spreads_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_sovereign_cds_spreads(api_token="test1234567890123456", as_of="2024-06-01")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/credit-risk/sovereign/cds-spreads" in call_url
+    assert "filter[as_of]=2024-06-01" in call_url
+
+
+def test_default_spreads_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_sovereign_default_spreads(api_token="test1234567890123456", rating="Aaa")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/credit-risk/sovereign/default-spreads" in call_url
+    assert "filter[rating]=Aaa" in call_url
+
+
+def test_corporate_cmdi_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_corporate_cmdi(api_token="test1234567890123456", from_date="2024-01-01", to_date="2024-12-31")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/credit-risk/corporate/cmdi" in call_url
+    assert "filter[from]=2024-01-01" in call_url
+    assert "filter[to]=2024-12-31" in call_url
+
+
+def test_hqm_yields_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_corporate_hqm_yields(api_token="test1234567890123456", tenor="10", type="par")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/credit-risk/corporate/hqm-yields" in call_url
+    assert "filter[tenor]=10" in call_url
+    assert "filter[type]=par" in call_url
+
+
+def test_hqm_yields_invalid_type(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_corporate_hqm_yields(api_token="test1234567890123456", type="bad")
+
+
+def test_cds_market_aggregates_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_cds_market_aggregates(
+        api_token="test1234567890123456", metric="gross_notional", dimension="grade",
+    )
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/credit-risk/cds-market/aggregates" in call_url
+    assert "filter[metric]=gross_notional" in call_url
+    assert "filter[dimension]=grade" in call_url
+
+
+def test_invalid_pagination(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_sovereign_risk_premium(api_token="test1234567890123456", page_offset=-1)
+    with pytest.raises(ValueError):
+        api.get_sovereign_risk_premium(api_token="test1234567890123456", page_limit=0)
+
+
+def test_filter_values_are_url_encoded(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    # a value with a space and an ampersand must not break the query string
+    api.get_sovereign_risk_premium(api_token="test1234567890123456", region="A & B")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "filter[region]=A%20%26%20B" in call_url
+    # the raw ampersand must not appear inside the filter value
+    assert "filter[region]=A & B" not in call_url

--- a/tests/test_credit_sovereign_risk.py
+++ b/tests/test_credit_sovereign_risk.py
@@ -107,17 +107,38 @@ def test_hqm_yields_invalid_type(mock_session):
         api.get_corporate_hqm_yields(api_token="test1234567890123456", type="bad")
 
 
+def test_hqm_yields_csv_type(mock_session):
+    # server uses CsvIn(['spot','par']) -> a comma-separated combo is valid
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_corporate_hqm_yields(api_token="test1234567890123456", type="Spot, Par")
+
+    call_url = mock_session.get.call_args[0][0]
+    # normalised to lowercase, comma-joined, URL-encoded (',' -> %2C)
+    assert "filter[type]=spot%2Cpar" in call_url
+
+
+def test_hqm_yields_partial_invalid_csv_type(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_corporate_hqm_yields(api_token="test1234567890123456", type="spot,bad")
+
+
 def test_cds_market_aggregates_url(mock_session):
     _mock_response(mock_session)
     api = _make_api(mock_session)
     api.get_cds_market_aggregates(
         api_token="test1234567890123456", metric="gross_notional", dimension="grade",
+        value="Investment Grade", region="North America",
     )
 
     call_url = mock_session.get.call_args[0][0]
     assert "/credit-risk/cds-market/aggregates" in call_url
     assert "filter[metric]=gross_notional" in call_url
     assert "filter[dimension]=grade" in call_url
+    # value and region filters are supported (verified vs prometheus-web)
+    assert "filter[value]=Investment%20Grade" in call_url
+    assert "filter[region]=North%20America" in call_url
 
 
 def test_invalid_pagination(mock_session):

--- a/tests/test_credit_sovereign_risk.py
+++ b/tests/test_credit_sovereign_risk.py
@@ -93,7 +93,7 @@ def test_corporate_cmdi_url(mock_session):
 def test_hqm_yields_url(mock_session):
     _mock_response(mock_session)
     api = _make_api(mock_session)
-    api.get_corporate_hqm_yields(api_token="test1234567890123456", tenor="10", type="par")
+    api.get_corporate_hqm_yields(api_token="test1234567890123456", tenor="10", yield_type="par")
 
     call_url = mock_session.get.call_args[0][0]
     assert "/credit-risk/corporate/hqm-yields" in call_url
@@ -104,14 +104,14 @@ def test_hqm_yields_url(mock_session):
 def test_hqm_yields_invalid_type(mock_session):
     api = _make_api(mock_session)
     with pytest.raises(ValueError):
-        api.get_corporate_hqm_yields(api_token="test1234567890123456", type="bad")
+        api.get_corporate_hqm_yields(api_token="test1234567890123456", yield_type="bad")
 
 
 def test_hqm_yields_csv_type(mock_session):
     # server uses CsvIn(['spot','par']) -> a comma-separated combo is valid
     _mock_response(mock_session)
     api = _make_api(mock_session)
-    api.get_corporate_hqm_yields(api_token="test1234567890123456", type="Spot, Par")
+    api.get_corporate_hqm_yields(api_token="test1234567890123456", yield_type="Spot, Par")
 
     call_url = mock_session.get.call_args[0][0]
     # normalised to lowercase, comma-joined, URL-encoded (',' -> %2C)
@@ -121,7 +121,39 @@ def test_hqm_yields_csv_type(mock_session):
 def test_hqm_yields_partial_invalid_csv_type(mock_session):
     api = _make_api(mock_session)
     with pytest.raises(ValueError):
-        api.get_corporate_hqm_yields(api_token="test1234567890123456", type="spot,bad")
+        api.get_corporate_hqm_yields(api_token="test1234567890123456", yield_type="spot,bad")
+
+
+def test_hqm_yields_blank_type_omitted(mock_session):
+    # a blank/empty yield_type is treated as "no filter", not a ValueError
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_corporate_hqm_yields(api_token="test1234567890123456", yield_type="  ,  ")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "filter[type]" not in call_url
+
+
+def test_blank_filter_omitted(mock_session):
+    # empty/whitespace-only filter values are omitted, not sent as &filter[key]=
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_sovereign_credit_ratings(api_token="test1234567890123456", country="   ")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "filter[country]" not in call_url
+
+
+def test_pagination_upper_bound(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_sovereign_risk_premium(api_token="test1234567890123456", page_limit=101)
+
+
+def test_pagination_rejects_bool(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_sovereign_risk_premium(api_token="test1234567890123456", page_offset=True)
 
 
 def test_cds_market_aggregates_url(mock_session):

--- a/tests/test_interest_rates.py
+++ b/tests/test_interest_rates.py
@@ -1,0 +1,104 @@
+"""Tests for InterestRatesAPI."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from eodhd.APIs.InterestRatesAPI import InterestRatesAPI
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock()
+
+
+def _make_api(session):
+    return InterestRatesAPI(session=session)
+
+
+def _mock_response(session, data=None):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = data if data is not None else {"data": [], "meta": {}, "links": {}}
+    session.get.return_value = resp
+
+
+def test_reference_rates_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_reference_rates(api_token="test1234567890123456", code="SOFR", currency="USD")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/rates/reference-rates" in call_url
+    assert "filter[code]=SOFR" in call_url
+    assert "filter[currency]=USD" in call_url
+
+
+def test_reference_rates_pagination(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_reference_rates(
+        api_token="test1234567890123456", from_date="2024-01-01", to_date="2024-06-01",
+        page_offset=10, page_limit=100,
+    )
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "filter[from]=2024-01-01" in call_url
+    assert "filter[to]=2024-06-01" in call_url
+    assert "page[offset]=10" in call_url
+    assert "page[limit]=100" in call_url
+
+
+def test_reference_rates_invalid_currency(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_reference_rates(api_token="test1234567890123456", currency="JPY")
+
+
+def test_policy_rates_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_policy_rates(
+        api_token="test1234567890123456", code="FEDFUNDS", country="USA",
+        central_bank="Federal Reserve",
+    )
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/rates/policy-rates" in call_url
+    assert "filter[code]=FEDFUNDS" in call_url
+    assert "filter[country]=USA" in call_url
+    # filter values are URL-encoded (spaces -> %20)
+    assert "filter[central_bank]=Federal%20Reserve" in call_url
+
+
+def test_funding_stress_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_funding_stress(
+        api_token="test1234567890123456", code="SOFR_OIS", from_date="2024-01-01",
+        to_date="2024-06-01",
+    )
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/spreads/funding-stress" in call_url
+    assert "filter[code]=SOFR_OIS" in call_url
+    assert "filter[from]=2024-01-01" in call_url
+    assert "filter[to]=2024-06-01" in call_url
+
+
+def test_funding_stress_no_pagination_kwargs(mock_session):
+    # funding-stress has no pagination params; calling with only filters works
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_funding_stress(api_token="test1234567890123456", code="TED")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "page[offset]" not in call_url
+    assert "page[limit]" not in call_url
+
+
+def test_invalid_pagination(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_reference_rates(api_token="test1234567890123456", page_offset=-1)
+    with pytest.raises(ValueError):
+        api.get_policy_rates(api_token="test1234567890123456", page_limit=0)

--- a/tests/test_interest_rates.py
+++ b/tests/test_interest_rates.py
@@ -48,10 +48,23 @@ def test_reference_rates_pagination(mock_session):
     assert "page[limit]=100" in call_url
 
 
-def test_reference_rates_invalid_currency(mock_session):
+def test_reference_rates_currency_uppercased(mock_session):
+    _mock_response(mock_session)
     api = _make_api(mock_session)
-    with pytest.raises(ValueError):
-        api.get_reference_rates(api_token="test1234567890123456", currency="JPY")
+    api.get_reference_rates(api_token="test1234567890123456", currency="usd")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "filter[currency]=USD" in call_url
+
+
+def test_reference_rates_currency_not_restricted(mock_session):
+    # currency is not enum-restricted server-side; the client must not reject it
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_reference_rates(api_token="test1234567890123456", currency="JPY")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "filter[currency]=JPY" in call_url
 
 
 def test_policy_rates_url(mock_session):

--- a/tests/test_sanctions.py
+++ b/tests/test_sanctions.py
@@ -1,0 +1,190 @@
+"""Tests for SanctionsAPI.
+
+Note: sanctions endpoints use BARE query params (program=, q=, type=, active=,
+imo=, flag=, vessel_type=, source=, country=), NOT filter[...]. Pagination still
+uses page[offset]/page[limit].
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from eodhd.APIs.SanctionsAPI import SanctionsAPI
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock()
+
+
+def _make_api(session):
+    return SanctionsAPI(session=session)
+
+
+def _mock_response(session, data=None):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = data if data is not None else {"data": [], "meta": {}, "links": {}}
+    session.get.return_value = resp
+
+
+def test_entities_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_entities(api_token="test1234567890123456")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/sanctions/entities" in call_url
+    assert "api_token=test1234567890123456" in call_url
+
+
+def test_entities_bare_params(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_entities(
+        api_token="test1234567890123456", q="Acme", program="OFAC-SDN",
+        country="RU", source="ofac", entity_type="individual", active=True,
+        page_offset=0, page_limit=25,
+    )
+
+    call_url = mock_session.get.call_args[0][0]
+    # bare keys, not filter[...]
+    assert "&q=Acme" in call_url
+    assert "&program=OFAC-SDN" in call_url
+    assert "&country=RU" in call_url
+    assert "&source=ofac" in call_url
+    assert "&type=individual" in call_url
+    assert "&active=true" in call_url
+    assert "page[offset]=0" in call_url
+    assert "page[limit]=25" in call_url
+    # must NOT use filter[...] style
+    assert "filter[" not in call_url
+
+
+def test_entities_active_false(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_entities(api_token="test1234567890123456", active=False)
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "&active=false" in call_url
+
+
+def test_entities_q_too_short(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_entities(api_token="test1234567890123456", q="a")
+
+
+def test_entities_invalid_source(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_entities(api_token="test1234567890123456", source="eu")
+
+
+def test_entities_invalid_type(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_entities(api_token="test1234567890123456", entity_type="ship")
+
+
+def test_entities_value_url_encoded(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_entities(api_token="test1234567890123456", program="A & B")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "&program=A%20%26%20B" in call_url
+    assert "&program=A & B" not in call_url
+
+
+def test_vessels_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_vessels(
+        api_token="test1234567890123456", imo="9074729", flag="RU",
+        vessel_type="cargo", q="tanker", program="OFAC-SDN", source="ofac",
+    )
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/sanctions/vessels" in call_url
+    assert "&imo=9074729" in call_url
+    assert "&flag=RU" in call_url
+    assert "&vessel_type=cargo" in call_url
+    assert "&q=tanker" in call_url
+    assert "&program=OFAC-SDN" in call_url
+    assert "&source=ofac" in call_url
+    assert "filter[" not in call_url
+
+
+def test_vessels_q_too_short(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_vessels(api_token="test1234567890123456", q="x")
+
+
+def test_vessels_invalid_source(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_vessels(api_token="test1234567890123456", source="un")
+
+
+def test_programs_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_programs(api_token="test1234567890123456", page_limit=100)
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/sanctions/programs" in call_url
+    assert "page[limit]=100" in call_url
+
+
+def test_sources_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_sources(api_token="test1234567890123456")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/sanctions/sources" in call_url
+
+
+def test_invalid_pagination(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_entities(api_token="test1234567890123456", page_offset=-1)
+    with pytest.raises(ValueError):
+        api.get_entities(api_token="test1234567890123456", page_limit=0)
+
+
+def test_active_string_accepted(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_entities(api_token="test1234567890123456", active="TRUE")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "&active=true" in call_url
+
+
+def test_active_invalid_value(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_entities(api_token="test1234567890123456", active="yes")
+
+
+def test_source_whitespace_tolerated(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    # surrounding whitespace should not cause a spurious ValueError
+    api.get_entities(api_token="test1234567890123456", source="ofac ")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "&source=ofac" in call_url
+
+
+def test_blank_value_omitted(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    # empty/whitespace-only values are omitted, not sent as &program=
+    api.get_entities(api_token="test1234567890123456", program="   ")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "&program=" not in call_url

--- a/tests/test_sanctions.py
+++ b/tests/test_sanctions.py
@@ -1,8 +1,9 @@
 """Tests for SanctionsAPI.
 
 Note: sanctions endpoints use BARE query params (program=, q=, type=, active=,
-imo=, flag=, vessel_type=, source=, country=), NOT filter[...]. Pagination still
-uses page[offset]/page[limit].
+imo=, flag=, vessel_type=, source=, country=), NOT filter[...]. Pagination
+(page[offset]/page[limit]) applies to entities and vessels only; programs and
+sources take no params and are not paginated.
 """
 
 import pytest
@@ -190,3 +191,23 @@ def test_blank_value_omitted(mock_session):
 
     call_url = mock_session.get.call_args[0][0]
     assert "&program=" not in call_url
+
+
+def test_blank_q_omitted_not_error(mock_session):
+    # a blank q must be treated as absent (omitted), not rejected as < 2 chars
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_entities(api_token="test1234567890123456", q="   ")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "&q=" not in call_url
+
+
+def test_blank_source_omitted_not_error(mock_session):
+    # a blank source must be omitted, not rejected against the enum
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_entities(api_token="test1234567890123456", source="   ")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "&source=" not in call_url

--- a/tests/test_sanctions.py
+++ b/tests/test_sanctions.py
@@ -131,11 +131,12 @@ def test_vessels_invalid_source(mock_session):
 def test_programs_url(mock_session):
     _mock_response(mock_session)
     api = _make_api(mock_session)
-    api.get_programs(api_token="test1234567890123456", page_limit=100)
+    api.get_programs(api_token="test1234567890123456")
 
     call_url = mock_session.get.call_args[0][0]
     assert "/sanctions/programs" in call_url
-    assert "page[limit]=100" in call_url
+    # programs is not paginated server-side; no page params are sent
+    assert "page[" not in call_url
 
 
 def test_sources_url(mock_session):
@@ -145,6 +146,7 @@ def test_sources_url(mock_session):
 
     call_url = mock_session.get.call_args[0][0]
     assert "/sanctions/sources" in call_url
+    assert "page[" not in call_url
 
 
 def test_invalid_pagination(mock_session):


### PR DESCRIPTION
New API classes CreditSovereignRiskAPI / SanctionsAPI / InterestRatesAPI (14 methods) + facade + tests. pytest: 105 passed. Filter values URL-encoded.

Part of an updatelibs cross-repo sync adding 3 API families / 14 endpoints — Credit & Sovereign Risk (7), Sanctions/OFAC (4), Interest Rates (3) — across EODHD-openapi, Node SDK, Python SDK, Postman, and the Claude plugin. Sanctions uses bare query params (verified vs prometheus-web request classes + live prod); credit-risk & interest-rates use filter[...]. Bridge pre-push review (Codex + Gemini): no blockers.