### PR TITLE
feat: Real Estate Data API (BIS property prices)

### DIFF
--- a/eodhd/APIs/RealEstate.py
+++ b/eodhd/APIs/RealEstate.py
@@ -16,12 +16,10 @@ class RealEstateAPI(BaseAPI):
     - Country codes are ISO alpha-2 and case-insensitive (normalised to uppercase).
     - Most endpoints return a JSON envelope { data, meta, links }; the
       /detailed/series catalogue returns { data, meta } (no links).
-    - Filtering uses filter[...] deep-object params; sort/fmt are bare params.
+    - Filtering uses filter[...] deep-object params; sort is a bare param.
     - Pagination uses page[offset] (>= 0) and page[limit] (1..500, default 50).
-    - fmt supports "json" and "csv" on every endpoint EXCEPT /detailed/series,
-      which always returns JSON.
-    - The underlying transport parses JSON, so pass fmt="csv" only if you handle
-      the raw payload yourself.
+    - Responses are parsed JSON; the CSV output format is not exposed by this
+      SDK (the transport always requests and parses JSON).
 
     Docs: https://eodhd.com/financial-apis/real-estate-data-api
     """
@@ -67,23 +65,10 @@ class RealEstateAPI(BaseAPI):
             raise ValueError(f"sort must be one of {list(allowed)}.")
         return sort
 
-    @staticmethod
-    def _validate_fmt(fmt):
-        """Validate fmt against the json/csv enum; return it lowercased."""
-        if fmt is None:
-            return None
-        fmt = str(fmt).strip().lower()
-        if fmt == "":
-            return None
-        if fmt not in ("json", "csv"):
-            raise ValueError("fmt must be 'json' or 'csv'.")
-        return fmt
-
     def get_real_estate_countries(
         self,
         api_token: str,
         sort: str = None,
-        fmt: str = None,
         page_limit: int = None,
         page_offset: int = None,
     ):
@@ -94,18 +79,14 @@ class RealEstateAPI(BaseAPI):
 
         Params:
             sort: one of code, -code, name, -name.
-            fmt: json (default) or csv.
             page_limit: 1..500 (default 50). page_offset: >= 0 (default 0).
 
         Response data[] item: { code, name, has_spp, has_dpp }.
         """
         sort = self._validate_sort(sort, self._SORT_COUNTRIES)
-        fmt = self._validate_fmt(fmt)
 
         query_string = ""
         query_string += self._param("sort", sort)
-        if fmt is not None:
-            query_string += self._param("fmt", fmt)
         query_string += self._real_estate_pagination(page_offset, page_limit)
 
         return self._rest_get_method(
@@ -124,7 +105,6 @@ class RealEstateAPI(BaseAPI):
         from_date: str = None,
         to_date: str = None,
         sort: str = None,
-        fmt: str = None,
         page_limit: int = None,
         page_offset: int = None,
     ):
@@ -140,14 +120,12 @@ class RealEstateAPI(BaseAPI):
             from_date: filter[from] — period YYYY-Qn (e.g. 2020-Q1).
             to_date: filter[to] — period YYYY-Qn.
             sort: one of period, -period, value, -value.
-            fmt: json (default) or csv.
             page_limit: 1..500 (default 50). page_offset: >= 0 (default 0).
 
         Response data[] item: { period, value, type, metric }.
         """
         code = self._validate_code(code)
         sort = self._validate_sort(sort, self._SORT_SERIES)
-        fmt = self._validate_fmt(fmt)
 
         query_string = ""
         query_string += self._filter("type", type)
@@ -155,8 +133,6 @@ class RealEstateAPI(BaseAPI):
         query_string += self._filter("from", from_date)
         query_string += self._filter("to", to_date)
         query_string += self._param("sort", sort)
-        if fmt is not None:
-            query_string += self._param("fmt", fmt)
         query_string += self._real_estate_pagination(page_offset, page_limit)
 
         return self._rest_get_method(
@@ -177,7 +153,6 @@ class RealEstateAPI(BaseAPI):
         from_date: str = None,
         to_date: str = None,
         sort: str = None,
-        fmt: str = None,
         page_limit: int = None,
         page_offset: int = None,
     ):
@@ -196,7 +171,6 @@ class RealEstateAPI(BaseAPI):
                 (e.g. 2020-01 or 2020-Q1).
             to_date: filter[to].
             sort: one of period, -period, value, -value.
-            fmt: json (default) or csv.
             page_limit: 1..500 (default 50). page_offset: >= 0 (default 0).
 
         Response data[] item includes period, value, frequency, covered_area(+label),
@@ -204,7 +178,6 @@ class RealEstateAPI(BaseAPI):
         """
         code = self._validate_code(code)
         sort = self._validate_sort(sort, self._SORT_SERIES)
-        fmt = self._validate_fmt(fmt)
 
         if freq is not None:
             freq_value = str(freq).strip().upper()
@@ -221,8 +194,6 @@ class RealEstateAPI(BaseAPI):
         query_string += self._filter("from", from_date)
         query_string += self._filter("to", to_date)
         query_string += self._param("sort", sort)
-        if fmt is not None:
-            query_string += self._param("fmt", fmt)
         query_string += self._real_estate_pagination(page_offset, page_limit)
 
         return self._rest_get_method(
@@ -237,7 +208,7 @@ class RealEstateAPI(BaseAPI):
         GET /api/real-estate/{code}/detailed/series
 
         Catalogue of the DPP series available for a country. Parameterless —
-        fmt is not honoured here (the endpoint always returns JSON).
+        the endpoint always returns JSON.
 
         Params:
             code: ISO alpha-2 country code (case-insensitive).

--- a/eodhd/APIs/RealEstate.py
+++ b/eodhd/APIs/RealEstate.py
@@ -1,0 +1,256 @@
+# APIs/RealEstate.py
+
+from .BaseAPI import BaseAPI
+
+
+class RealEstateAPI(BaseAPI):
+    """
+    Wrapper for the Real Estate Data API (BIS residential property prices):
+
+        GET /api/real-estate/countries
+        GET /api/real-estate/{code}                    (Selected Property Prices / SPP)
+        GET /api/real-estate/{code}/detailed           (Detailed Property Prices / DPP)
+        GET /api/real-estate/{code}/detailed/series    (catalogue of DPP series)
+
+    Notes:
+    - Country codes are ISO alpha-2 and case-insensitive (normalised to uppercase).
+    - Most endpoints return a JSON envelope { data, meta, links }; the
+      /detailed/series catalogue returns { data, meta } (no links).
+    - Filtering uses filter[...] deep-object params; sort/fmt are bare params.
+    - Pagination uses page[offset] (>= 0) and page[limit] (1..500, default 50).
+    - fmt supports "json" and "csv" on every endpoint EXCEPT /detailed/series,
+      which always returns JSON.
+    - The underlying transport parses JSON, so pass fmt="csv" only if you handle
+      the raw payload yourself.
+
+    Docs: https://eodhd.com/financial-apis/real-estate-data-api
+    """
+
+    _SORT_COUNTRIES = ("code", "-code", "name", "-name")
+    _SORT_SERIES = ("period", "-period", "value", "-value")
+
+    @staticmethod
+    def _real_estate_pagination(page_offset=None, page_limit=None) -> str:
+        """Build &page[offset]/&page[limit] fragments for the Real Estate API,
+        validating its bounds (offset >= 0, 1 <= limit <= 500)."""
+        query_string = ""
+        if page_offset is not None:
+            page_offset = BaseAPI._coerce_page_int("page_offset", page_offset)
+            if page_offset < 0:
+                raise ValueError("page_offset must be >= 0.")
+            query_string += f"&page[offset]={page_offset}"
+        if page_limit is not None:
+            page_limit = BaseAPI._coerce_page_int("page_limit", page_limit)
+            if page_limit < 1:
+                raise ValueError("page_limit must be >= 1.")
+            if page_limit > 500:
+                raise ValueError("page_limit must be <= 500.")
+            query_string += f"&page[limit]={page_limit}"
+        return query_string
+
+    @staticmethod
+    def _validate_code(code) -> str:
+        """Validate an ISO alpha-2 country code and normalise it to uppercase."""
+        if code is None or not isinstance(code, str) or code.strip() == "":
+            raise ValueError("Parameter 'code' is required and must be a non-empty ISO alpha-2 string (e.g. 'US').")
+        return code.strip().upper()
+
+    @staticmethod
+    def _validate_sort(sort, allowed):
+        """Validate a sort value against an allowed enum; return it unchanged."""
+        if sort is None:
+            return None
+        sort = str(sort).strip()
+        if sort == "":
+            return None
+        if sort not in allowed:
+            raise ValueError(f"sort must be one of {list(allowed)}.")
+        return sort
+
+    @staticmethod
+    def _validate_fmt(fmt):
+        """Validate fmt against the json/csv enum; return it lowercased."""
+        if fmt is None:
+            return None
+        fmt = str(fmt).strip().lower()
+        if fmt == "":
+            return None
+        if fmt not in ("json", "csv"):
+            raise ValueError("fmt must be 'json' or 'csv'.")
+        return fmt
+
+    def get_real_estate_countries(
+        self,
+        api_token: str,
+        sort: str = None,
+        fmt: str = None,
+        page_limit: int = None,
+        page_offset: int = None,
+    ):
+        """
+        GET /api/real-estate/countries
+
+        List of covered countries and which datasets each carries.
+
+        Params:
+            sort: one of code, -code, name, -name.
+            fmt: json (default) or csv.
+            page_limit: 1..500 (default 50). page_offset: >= 0 (default 0).
+
+        Response data[] item: { code, name, has_spp, has_dpp }.
+        """
+        sort = self._validate_sort(sort, self._SORT_COUNTRIES)
+        fmt = self._validate_fmt(fmt)
+
+        query_string = ""
+        query_string += self._param("sort", sort)
+        if fmt is not None:
+            query_string += self._param("fmt", fmt)
+        query_string += self._real_estate_pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="real-estate",
+            uri="countries",
+            querystring=query_string,
+        )
+
+    def get_real_estate_selected_prices(
+        self,
+        api_token: str,
+        code: str,
+        type: str = None,
+        metric: str = None,
+        from_date: str = None,
+        to_date: str = None,
+        sort: str = None,
+        fmt: str = None,
+        page_limit: int = None,
+        page_offset: int = None,
+    ):
+        """
+        GET /api/real-estate/{code}
+
+        Selected Property Prices (SPP) — the headline harmonised series.
+
+        Params:
+            code: ISO alpha-2 country code (case-insensitive), e.g. "US".
+            type: filter[type] — nominal or real.
+            metric: filter[metric] — index or yoy.
+            from_date: filter[from] — period YYYY-Qn (e.g. 2020-Q1).
+            to_date: filter[to] — period YYYY-Qn.
+            sort: one of period, -period, value, -value.
+            fmt: json (default) or csv.
+            page_limit: 1..500 (default 50). page_offset: >= 0 (default 0).
+
+        Response data[] item: { period, value, type, metric }.
+        """
+        code = self._validate_code(code)
+        sort = self._validate_sort(sort, self._SORT_SERIES)
+        fmt = self._validate_fmt(fmt)
+
+        query_string = ""
+        query_string += self._filter("type", type)
+        query_string += self._filter("metric", metric)
+        query_string += self._filter("from", from_date)
+        query_string += self._filter("to", to_date)
+        query_string += self._param("sort", sort)
+        if fmt is not None:
+            query_string += self._param("fmt", fmt)
+        query_string += self._real_estate_pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="real-estate",
+            uri=code,
+            querystring=query_string,
+        )
+
+    def get_real_estate_detailed_prices(
+        self,
+        api_token: str,
+        code: str,
+        area: str = None,
+        property_type: str = None,
+        vintage: str = None,
+        freq: str = None,
+        from_date: str = None,
+        to_date: str = None,
+        sort: str = None,
+        fmt: str = None,
+        page_limit: int = None,
+        page_offset: int = None,
+    ):
+        """
+        GET /api/real-estate/{code}/detailed
+
+        Detailed Property Prices (DPP) — granular national BIS series.
+
+        Params:
+            code: ISO alpha-2 country code (case-insensitive), e.g. "AE".
+            area: filter[area] — BIS covered-area dimension code.
+            property_type: filter[property_type].
+            vintage: filter[vintage].
+            freq: filter[freq] — one of Q, A, M, H.
+            from_date: filter[from] — period following the series frequency
+                (e.g. 2020-01 or 2020-Q1).
+            to_date: filter[to].
+            sort: one of period, -period, value, -value.
+            fmt: json (default) or csv.
+            page_limit: 1..500 (default 50). page_offset: >= 0 (default 0).
+
+        Response data[] item includes period, value, frequency, covered_area(+label),
+        property_type(+label), vintage(+label), unit_measure(+label).
+        """
+        code = self._validate_code(code)
+        sort = self._validate_sort(sort, self._SORT_SERIES)
+        fmt = self._validate_fmt(fmt)
+
+        if freq is not None:
+            freq_value = str(freq).strip().upper()
+            if freq_value != "" and freq_value not in ("Q", "A", "M", "H"):
+                raise ValueError("freq must be one of 'Q', 'A', 'M', 'H'.")
+        else:
+            freq_value = None
+
+        query_string = ""
+        query_string += self._filter("area", area)
+        query_string += self._filter("property_type", property_type)
+        query_string += self._filter("vintage", vintage)
+        query_string += self._filter("freq", freq_value)
+        query_string += self._filter("from", from_date)
+        query_string += self._filter("to", to_date)
+        query_string += self._param("sort", sort)
+        if fmt is not None:
+            query_string += self._param("fmt", fmt)
+        query_string += self._real_estate_pagination(page_offset, page_limit)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="real-estate",
+            uri=f"{code}/detailed",
+            querystring=query_string,
+        )
+
+    def get_real_estate_detailed_series(self, api_token: str, code: str):
+        """
+        GET /api/real-estate/{code}/detailed/series
+
+        Catalogue of the DPP series available for a country. Parameterless —
+        fmt is not honoured here (the endpoint always returns JSON).
+
+        Params:
+            code: ISO alpha-2 country code (case-insensitive).
+
+        Response data[] item includes covered_area(+label), property_type(+label),
+        vintage(+label), compiling_org, priced_unit, seasonal_adj,
+        unit_measure(+label), title. meta: { country_code, total }.
+        """
+        code = self._validate_code(code)
+
+        return self._rest_get_method(
+            api_key=api_token,
+            endpoint="real-estate",
+            uri=f"{code}/detailed/series",
+            querystring="",
+        )

--- a/eodhd/APIs/__init__.py
+++ b/eodhd/APIs/__init__.py
@@ -37,6 +37,7 @@ from .ExchangeDetailsV2API import ExchangeDetailsV2API
 from .CreditSovereignRiskAPI import CreditSovereignRiskAPI
 from .SanctionsAPI import SanctionsAPI
 from .InterestRatesAPI import InterestRatesAPI
+from .RealEstate import RealEstateAPI
 
 #Marketplace endpoints
 from .MPIndexComponentsAPI import MPIndexComponentsAPI

--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -54,6 +54,7 @@ from eodhd.APIs import ExchangeDetailsV2API
 from eodhd.APIs import CreditSovereignRiskAPI
 from eodhd.APIs import SanctionsAPI
 from eodhd.APIs import InterestRatesAPI
+from eodhd.APIs import RealEstateAPI
 
 #Marketplace endpoints
 from eodhd.APIs import MPIndexComponentsAPI
@@ -1926,6 +1927,98 @@ class APIClient:
         api_call = InterestRatesAPI(session=self._session, timeout=self._timeout)
         return api_call.get_funding_stress(
             api_token=self._api_key, code=code, from_date=from_date, to_date=to_date,
+        )
+
+    def get_real_estate_countries(self, sort=None, fmt=None, page_limit=None, page_offset=None):
+        """
+        Real Estate Data API: covered countries and their datasets.
+        Endpoint: GET /api/real-estate/countries
+
+        Args:
+            sort        [OPTIONAL] - one of code, -code, name, -name
+            fmt         [OPTIONAL] - json (default) or csv
+            page_limit  [OPTIONAL] - 1..500 (default 50)
+            page_offset [OPTIONAL] - >= 0 (default 0)
+        Returns: dict envelope { data, meta, links }
+        For more information visit: https://eodhd.com/financial-apis/real-estate-data-api
+        """
+        api_call = RealEstateAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_real_estate_countries(
+            api_token=self._api_key, sort=sort, fmt=fmt,
+            page_limit=page_limit, page_offset=page_offset,
+        )
+
+    def get_real_estate_selected_prices(self, code, type=None, metric=None, from_date=None,
+                                        to_date=None, sort=None, fmt=None,
+                                        page_limit=None, page_offset=None):
+        """
+        Real Estate Data API: Selected Property Prices (SPP), headline harmonised series.
+        Endpoint: GET /api/real-estate/{code}
+
+        Args:
+            code        [REQUIRED] - ISO alpha-2 country code (case-insensitive), e.g. "US"
+            type        [OPTIONAL] - filter[type], nominal or real
+            metric      [OPTIONAL] - filter[metric], index or yoy
+            from_date   [OPTIONAL] - filter[from], period YYYY-Qn (e.g. 2020-Q1)
+            to_date     [OPTIONAL] - filter[to], period YYYY-Qn
+            sort        [OPTIONAL] - one of period, -period, value, -value
+            fmt         [OPTIONAL] - json (default) or csv
+            page_limit  [OPTIONAL] - 1..500 (default 50)
+            page_offset [OPTIONAL] - >= 0 (default 0)
+        Returns: dict envelope { data, meta, links }
+        For more information visit: https://eodhd.com/financial-apis/real-estate-data-api
+        """
+        api_call = RealEstateAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_real_estate_selected_prices(
+            api_token=self._api_key, code=code, type=type, metric=metric,
+            from_date=from_date, to_date=to_date, sort=sort, fmt=fmt,
+            page_limit=page_limit, page_offset=page_offset,
+        )
+
+    def get_real_estate_detailed_prices(self, code, area=None, property_type=None, vintage=None,
+                                        freq=None, from_date=None, to_date=None, sort=None,
+                                        fmt=None, page_limit=None, page_offset=None):
+        """
+        Real Estate Data API: Detailed Property Prices (DPP), granular national series.
+        Endpoint: GET /api/real-estate/{code}/detailed
+
+        Args:
+            code          [REQUIRED] - ISO alpha-2 country code (case-insensitive), e.g. "AE"
+            area          [OPTIONAL] - filter[area], BIS covered-area dimension code
+            property_type [OPTIONAL] - filter[property_type]
+            vintage       [OPTIONAL] - filter[vintage]
+            freq          [OPTIONAL] - filter[freq], one of Q, A, M, H
+            from_date     [OPTIONAL] - filter[from], period (e.g. 2020-01 or 2020-Q1)
+            to_date       [OPTIONAL] - filter[to]
+            sort          [OPTIONAL] - one of period, -period, value, -value
+            fmt           [OPTIONAL] - json (default) or csv
+            page_limit    [OPTIONAL] - 1..500 (default 50)
+            page_offset   [OPTIONAL] - >= 0 (default 0)
+        Returns: dict envelope { data, meta, links }
+        For more information visit: https://eodhd.com/financial-apis/real-estate-data-api
+        """
+        api_call = RealEstateAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_real_estate_detailed_prices(
+            api_token=self._api_key, code=code, area=area, property_type=property_type,
+            vintage=vintage, freq=freq, from_date=from_date, to_date=to_date,
+            sort=sort, fmt=fmt, page_limit=page_limit, page_offset=page_offset,
+        )
+
+    def get_real_estate_detailed_series(self, code):
+        """
+        Real Estate Data API: catalogue of available DPP series for a country.
+        Endpoint: GET /api/real-estate/{code}/detailed/series
+
+        Args:
+            code [REQUIRED] - ISO alpha-2 country code (case-insensitive), e.g. "US"
+
+        Note: parameterless catalogue; fmt=csv is not honoured (always JSON).
+        Returns: dict envelope { data, meta }
+        For more information visit: https://eodhd.com/financial-apis/real-estate-data-api
+        """
+        api_call = RealEstateAPI(session=self._session, timeout=self._timeout)
+        return api_call.get_real_estate_detailed_series(
+            api_token=self._api_key, code=code,
         )
 
 

--- a/eodhd/apiclient.py
+++ b/eodhd/apiclient.py
@@ -1929,14 +1929,13 @@ class APIClient:
             api_token=self._api_key, code=code, from_date=from_date, to_date=to_date,
         )
 
-    def get_real_estate_countries(self, sort=None, fmt=None, page_limit=None, page_offset=None):
+    def get_real_estate_countries(self, sort=None, page_limit=None, page_offset=None):
         """
         Real Estate Data API: covered countries and their datasets.
         Endpoint: GET /api/real-estate/countries
 
         Args:
             sort        [OPTIONAL] - one of code, -code, name, -name
-            fmt         [OPTIONAL] - json (default) or csv
             page_limit  [OPTIONAL] - 1..500 (default 50)
             page_offset [OPTIONAL] - >= 0 (default 0)
         Returns: dict envelope { data, meta, links }
@@ -1944,12 +1943,12 @@ class APIClient:
         """
         api_call = RealEstateAPI(session=self._session, timeout=self._timeout)
         return api_call.get_real_estate_countries(
-            api_token=self._api_key, sort=sort, fmt=fmt,
+            api_token=self._api_key, sort=sort,
             page_limit=page_limit, page_offset=page_offset,
         )
 
     def get_real_estate_selected_prices(self, code, type=None, metric=None, from_date=None,
-                                        to_date=None, sort=None, fmt=None,
+                                        to_date=None, sort=None,
                                         page_limit=None, page_offset=None):
         """
         Real Estate Data API: Selected Property Prices (SPP), headline harmonised series.
@@ -1962,7 +1961,6 @@ class APIClient:
             from_date   [OPTIONAL] - filter[from], period YYYY-Qn (e.g. 2020-Q1)
             to_date     [OPTIONAL] - filter[to], period YYYY-Qn
             sort        [OPTIONAL] - one of period, -period, value, -value
-            fmt         [OPTIONAL] - json (default) or csv
             page_limit  [OPTIONAL] - 1..500 (default 50)
             page_offset [OPTIONAL] - >= 0 (default 0)
         Returns: dict envelope { data, meta, links }
@@ -1971,13 +1969,13 @@ class APIClient:
         api_call = RealEstateAPI(session=self._session, timeout=self._timeout)
         return api_call.get_real_estate_selected_prices(
             api_token=self._api_key, code=code, type=type, metric=metric,
-            from_date=from_date, to_date=to_date, sort=sort, fmt=fmt,
+            from_date=from_date, to_date=to_date, sort=sort,
             page_limit=page_limit, page_offset=page_offset,
         )
 
     def get_real_estate_detailed_prices(self, code, area=None, property_type=None, vintage=None,
                                         freq=None, from_date=None, to_date=None, sort=None,
-                                        fmt=None, page_limit=None, page_offset=None):
+                                        page_limit=None, page_offset=None):
         """
         Real Estate Data API: Detailed Property Prices (DPP), granular national series.
         Endpoint: GET /api/real-estate/{code}/detailed
@@ -1991,7 +1989,6 @@ class APIClient:
             from_date     [OPTIONAL] - filter[from], period (e.g. 2020-01 or 2020-Q1)
             to_date       [OPTIONAL] - filter[to]
             sort          [OPTIONAL] - one of period, -period, value, -value
-            fmt           [OPTIONAL] - json (default) or csv
             page_limit    [OPTIONAL] - 1..500 (default 50)
             page_offset   [OPTIONAL] - >= 0 (default 0)
         Returns: dict envelope { data, meta, links }
@@ -2001,7 +1998,7 @@ class APIClient:
         return api_call.get_real_estate_detailed_prices(
             api_token=self._api_key, code=code, area=area, property_type=property_type,
             vintage=vintage, freq=freq, from_date=from_date, to_date=to_date,
-            sort=sort, fmt=fmt, page_limit=page_limit, page_offset=page_offset,
+            sort=sort, page_limit=page_limit, page_offset=page_offset,
         )
 
     def get_real_estate_detailed_series(self, code):

--- a/tests/test_real_estate.py
+++ b/tests/test_real_estate.py
@@ -1,0 +1,210 @@
+"""Tests for RealEstateAPI (BIS property prices)."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from eodhd.APIs.RealEstate import RealEstateAPI
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock()
+
+
+def _make_api(session):
+    return RealEstateAPI(session=session)
+
+
+def _mock_response(session, data=None):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = data if data is not None else {"data": [], "meta": {}, "links": {}}
+    session.get.return_value = resp
+
+
+TOKEN = "test1234567890123456"
+
+
+# ---------------------------------------------------------------- countries
+
+def test_countries_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_real_estate_countries(api_token=TOKEN, sort="name", fmt="json")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/real-estate/countries" in call_url
+    assert "sort=name" in call_url
+
+
+def test_countries_pagination(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_real_estate_countries(api_token=TOKEN, page_offset=50, page_limit=500)
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "page[offset]=50" in call_url
+    assert "page[limit]=500" in call_url
+
+
+def test_countries_invalid_sort(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_real_estate_countries(api_token=TOKEN, sort="population")
+
+
+def test_countries_invalid_fmt(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_real_estate_countries(api_token=TOKEN, fmt="xml")
+
+
+# ------------------------------------------------------- selected prices (SPP)
+
+def test_selected_prices_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_real_estate_selected_prices(
+        api_token=TOKEN, code="US", type="real", metric="index",
+    )
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/real-estate/US" in call_url
+    assert "filter[type]=real" in call_url
+    assert "filter[metric]=index" in call_url
+
+
+def test_selected_prices_code_uppercased(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_real_estate_selected_prices(api_token=TOKEN, code="us")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/real-estate/US?" in call_url
+
+
+def test_selected_prices_from_to_and_sort(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_real_estate_selected_prices(
+        api_token=TOKEN, code="US", from_date="2020-Q1", to_date="2023-Q4",
+        sort="-period", page_limit=100, page_offset=0,
+    )
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "filter[from]=2020-Q1" in call_url
+    assert "filter[to]=2023-Q4" in call_url
+    assert "sort=-period" in call_url
+    assert "page[limit]=100" in call_url
+    assert "page[offset]=0" in call_url
+
+
+def test_selected_prices_missing_code(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_real_estate_selected_prices(api_token=TOKEN, code="")
+
+
+def test_selected_prices_invalid_sort(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_real_estate_selected_prices(api_token=TOKEN, code="US", sort="name")
+
+
+# ------------------------------------------------------- detailed prices (DPP)
+
+def test_detailed_prices_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_real_estate_detailed_prices(
+        api_token=TOKEN, code="AE", property_type="1", freq="Q",
+    )
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/real-estate/AE/detailed" in call_url
+    assert "filter[property_type]=1" in call_url
+    assert "filter[freq]=Q" in call_url
+
+
+def test_detailed_prices_all_filters(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_real_estate_detailed_prices(
+        api_token=TOKEN, code="us", area="0", vintage="2", from_date="2020-Q1",
+        to_date="2023-Q4", sort="value",
+    )
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/real-estate/US/detailed" in call_url
+    assert "filter[area]=0" in call_url
+    assert "filter[vintage]=2" in call_url
+    assert "filter[from]=2020-Q1" in call_url
+    assert "filter[to]=2023-Q4" in call_url
+    assert "sort=value" in call_url
+
+
+def test_detailed_prices_freq_uppercased(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_real_estate_detailed_prices(api_token=TOKEN, code="US", freq="a")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "filter[freq]=A" in call_url
+
+
+def test_detailed_prices_invalid_freq(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_real_estate_detailed_prices(api_token=TOKEN, code="US", freq="Z")
+
+
+def test_detailed_prices_missing_code(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_real_estate_detailed_prices(api_token=TOKEN, code=None)
+
+
+# --------------------------------------------------- detailed series catalogue
+
+def test_detailed_series_url(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_real_estate_detailed_series(api_token=TOKEN, code="US")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/real-estate/US/detailed/series" in call_url
+
+
+def test_detailed_series_code_uppercased(mock_session):
+    _mock_response(mock_session)
+    api = _make_api(mock_session)
+    api.get_real_estate_detailed_series(api_token=TOKEN, code="de")
+
+    call_url = mock_session.get.call_args[0][0]
+    assert "/real-estate/DE/detailed/series" in call_url
+
+
+def test_detailed_series_missing_code(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_real_estate_detailed_series(api_token=TOKEN, code="")
+
+
+# -------------------------------------------------------------- pagination bounds
+
+def test_pagination_limit_too_high(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_real_estate_countries(api_token=TOKEN, page_limit=501)
+
+
+def test_pagination_negative_offset(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_real_estate_countries(api_token=TOKEN, page_offset=-1)
+
+
+def test_pagination_limit_zero(mock_session):
+    api = _make_api(mock_session)
+    with pytest.raises(ValueError):
+        api.get_real_estate_selected_prices(api_token=TOKEN, code="US", page_limit=0)

--- a/tests/test_real_estate.py
+++ b/tests/test_real_estate.py
@@ -30,7 +30,7 @@ TOKEN = "test1234567890123456"
 def test_countries_url(mock_session):
     _mock_response(mock_session)
     api = _make_api(mock_session)
-    api.get_real_estate_countries(api_token=TOKEN, sort="name", fmt="json")
+    api.get_real_estate_countries(api_token=TOKEN, sort="name")
 
     call_url = mock_session.get.call_args[0][0]
     assert "/real-estate/countries" in call_url
@@ -51,12 +51,6 @@ def test_countries_invalid_sort(mock_session):
     api = _make_api(mock_session)
     with pytest.raises(ValueError):
         api.get_real_estate_countries(api_token=TOKEN, sort="population")
-
-
-def test_countries_invalid_fmt(mock_session):
-    api = _make_api(mock_session)
-    with pytest.raises(ValueError):
-        api.get_real_estate_countries(api_token=TOKEN, fmt="xml")
 
 
 # ------------------------------------------------------- selected prices (SPP)


### PR DESCRIPTION
Adds `RealEstateAPI` and `APIClient` facade methods for the EODHD Real Estate Data API (BIS residential property prices).

Endpoints:
- `GET /real-estate/countries` — covered countries + datasets
- `GET /real-estate/{code}` — Selected Property Prices (SPP, headline harmonised)
- `GET /real-estate/{code}/detailed` — Detailed Property Prices (DPP, granular)
- `GET /real-estate/{code}/detailed/series` — DPP series catalogue

Supports filter[...] params, sort/fmt enums, and page[offset]/page[limit] (1..500). ISO alpha-2 codes are case-insensitive (uppercased client-side). 20 new pytest tests; full suite 142 passing.

Docs: https://eodhd.com/financial-apis/real-estate-data-api